### PR TITLE
Run a query directly from the graph if possible

### DIFF
--- a/Jinaga.Test/Facts/OptimizationTest.cs
+++ b/Jinaga.Test/Facts/OptimizationTest.cs
@@ -107,5 +107,24 @@ namespace Jinaga.Test.Facts
             var user = emitter.Deserialize<User>(userReference);
             user.publicKey.Should().Be("--- PUBLIC KEY ---");
         }
+
+        [Fact]
+        public async Task Optimization_RunPipelineOnGraph()
+        {
+            var userWithName = Given<PassengerName>.Match(passengerName =>
+                passengerName.passenger.user);
+
+            var pipeline = userWithName.Pipeline;
+            var passenger = new Passenger(new Airline("IA"), new User("--- PUBLIC KEY ---"));
+            var passengerName = new PassengerName(passenger, "George", new PassengerName[0]);
+
+            // This instance does not contain the facts.
+            var j = JinagaTest.Create();
+            var users = await j.Query(passengerName, userWithName);
+
+            // But the graph does.
+            users.Should().ContainSingle().Which
+                .publicKey.Should().Be("--- PUBLIC KEY ---");
+        }
     }
 }

--- a/Jinaga.UnitTest/MemoryStore.cs
+++ b/Jinaga.UnitTest/MemoryStore.cs
@@ -52,6 +52,10 @@ namespace Jinaga.UnitTest
 
         public Task<ImmutableList<Product>> Query(FactReference startReference, Pipeline pipeline, CancellationToken cancellationToken)
         {
+            if (pipeline.CanRunOnGraph)
+            {
+                throw new ArgumentException("This pipeline can run on the graph. Do that.");
+            }
             var products = ExecutePipeline(startReference, pipeline);
             return Task.FromResult(products);
         }

--- a/Jinaga/Facts/Fact.cs
+++ b/Jinaga/Facts/Fact.cs
@@ -88,6 +88,27 @@ namespace Jinaga.Facts
             }
         }
 
+        public ImmutableList<FactReference> GetPredecessors(string role)
+        {
+            var references = Predecessors
+                .Where(p => p.Role == role)
+                .ToImmutableList();
+            if (references.Count == 0)
+            {
+                throw new ArgumentException($"The fact {Reference.Type} did not contain any predecessors in role {role}");
+            }
+            else if (references.Count > 1)
+            {
+                throw new ArgumentException($"The fact {Reference.Type} contained {references.Count} predecessors in role {role}; there should only be 1");
+            }
+            return references.Single() switch
+            {
+                PredecessorSingle single => ImmutableList<FactReference>.Empty.Add(single.Reference),
+                PredecessorMultiple multiple => multiple.References,
+                _ => throw new InvalidOperationException("Unknown predecessor type")
+            };
+        }
+
         private static string ComputeHash(ImmutableList<Field> fields, ImmutableList<Predecessor> predecessors)
         {
             string json = Canonicalize(fields, predecessors);

--- a/Jinaga/Jinaga.cs
+++ b/Jinaga/Jinaga.cs
@@ -47,8 +47,7 @@ namespace Jinaga
             if (pipeline.CanRunOnGraph)
             {
                 var products = pipeline.Execute(startReference, graph);
-                var projection = specification.Projection;
-                return projection switch
+                return specification.Projection switch
                 {
                     SimpleProjection simple => products
                         .Select(product => factManager.Deserialize<TProjection>(

--- a/Jinaga/Observer.cs
+++ b/Jinaga/Observer.cs
@@ -86,10 +86,12 @@ namespace Jinaga
                     .ToImmutableList();
                 if (matchingReferences.Any())
                 {
-                    var products = await factManager.QueryAll(
-                        startReferences,
-                        inversePipeline,
-                        cancellationToken);
+                    var products = inversePipeline.CanRunOnGraph
+                        ? inversePipeline.Execute(startReferences, graph)
+                        : await factManager.QueryAll(
+                            startReferences,
+                            inversePipeline,
+                            cancellationToken);
                     foreach (var product in products)
                     {
                         var identifyingProduct = inverse.Subset.Of(product);

--- a/Jinaga/Pipelines/Pipeline.cs
+++ b/Jinaga/Pipelines/Pipeline.cs
@@ -73,11 +73,18 @@ namespace Jinaga.Pipelines
 
         public ImmutableList<Product> Execute(FactReference startReference, FactGraph graph)
         {
-            var initialTag = starts.Single().Name;
-            var startingProducts = new Product[]
-            {
-                Product.Empty.With(initialTag, startReference)
-            }.ToImmutableList();
+            return Execute(ImmutableList<FactReference>.Empty.Add(startReference), graph);
+        }
+
+        public ImmutableList<Product> Execute(ImmutableList<FactReference> startReferences, FactGraph graph)
+        {
+            var start = starts.Single();
+            var initialTag = start.Name;
+            var initialType = start.Type;
+            var startingProducts = startReferences
+                .Where(startReference => startReference.Type == initialType)
+                .Select(startReference => Product.Empty.With(initialTag, startReference))
+                .ToImmutableList();
             return paths.Aggregate(
                 startingProducts,
                 (products, path) => path.Execute(products, graph)


### PR DESCRIPTION
Some queries, especially inverses or authorizatiion rules, use only predecessors. When this is the case, and you have a graph that includes the transitive closure, you can run the query without going back to the store.