### PR TITLE
Enter date in ISO8601 format to avoid failure in not-MM/dd/yyyy-cultures

### DIFF
--- a/Jinaga.Test/Facts/DeserializeTest.cs
+++ b/Jinaga.Test/Facts/DeserializeTest.cs
@@ -27,7 +27,7 @@ namespace Jinaga.Test.Facts
         [Fact]
         public void Deserialize_DateField()
         {
-            DateTime now = DateTime.Parse("7/4/2021 1:39:43.241Z");
+            DateTime now = DateTime.Parse("2021-07-04T01:39:43.241Z");
             var fact = Fact.Create(
                 "Skylane.Airline",
                 ImmutableList<Field>.Empty.Add(new Field("identifier", new FieldValueString("value"))),

--- a/Jinaga.Test/Facts/SerializeTest.cs
+++ b/Jinaga.Test/Facts/SerializeTest.cs
@@ -32,8 +32,8 @@ namespace Jinaga.Test.Facts
 
         [Fact]
         public void SerializeDateTimeField()
-        {
-            DateTime now = DateTime.Parse("7/4/2021 1:39:43.241Z");
+        {            
+            DateTime now = DateTime.Parse("2021-07-04T01:39:43.241Z");
             var graph = Serialize(new AirlineDay(new Airline("value"), now));
 
             var airlineDay = graph.GetFact(graph.Last);

--- a/Jinaga.Test/Facts/StoreTest.cs
+++ b/Jinaga.Test/Facts/StoreTest.cs
@@ -12,7 +12,7 @@ namespace Jinaga.Test.Facts
         [Fact]
         public async Task StoreRoundTripToUTC()
         {
-            DateTime now = DateTime.Parse("7/4/2021 1:39:43.241Z");
+            DateTime now = DateTime.Parse("2021-07-04T01:39:43.241Z");
             var j = JinagaTest.Create();
             var airlineDay = await j.Fact(new AirlineDay(new Airline("value"), now));
             airlineDay.date.Kind.Should().Be(DateTimeKind.Utc);
@@ -22,7 +22,7 @@ namespace Jinaga.Test.Facts
         [Fact]
         public async Task StoreRoundTripFromUTC()
         {
-            DateTime now = DateTime.Parse("7/4/2021 1:39:43.241Z").ToUniversalTime();
+            DateTime now = DateTime.Parse("2021-07-04T01:39:43.241Z").ToUniversalTime();
             var j = JinagaTest.Create();
             var airlineDay = await j.Fact(new AirlineDay(new Airline("value"), now));
             airlineDay.date.Kind.Should().Be(DateTimeKind.Utc);


### PR DESCRIPTION
The "SerializeDateTimeField"-test failed on a system with (Dutch)-BELGIUM regional settings.
A few other tests contained the same bug, but passed because testing was less strict.