### PR TITLE
Inline Collections

### DIFF
--- a/Documentation/Blog.dib
+++ b/Documentation/Blog.dib
@@ -1,6 +1,6 @@
 #!csharp
 
-#r "C:\Projects\jinaga.net\Jinaga\bin\Debug\netstandard2.1\Jinaga.dll"
+#r "C:\Users\micha\Projects\jinaga.net\Jinaga\bin\Debug\netstandard2.1\Jinaga.dll"
 
 #!csharp
 
@@ -41,7 +41,12 @@ var specification = Given<Site>.Match((site, facts) =>
     select new
     {
         postCreatedAt = post.createdAt,
-        titles = facts.All(post, postTitles)
+        titles = facts.Observable(post, postTitles),
+        newTitles = facts.Observable(
+            from title in facts.OfType<Title>()
+            where title.post == post
+            where !facts.OfType<Title>(next => next.prior.Contains(title)).Any()
+            select title.value)
     }
 );
 

--- a/Documentation/DifferentPipelines.dib
+++ b/Documentation/DifferentPipelines.dib
@@ -28,8 +28,8 @@ var simpleSpecification = Given<Airline>.Match((airline, facts) =>
     select cancellation
 );
 
-simpleSpecification.Pipeline.ToDescriptiveString()
+simpleSpecification.ToDescriptiveString()
 
 #!csharp
 
-compoundSpecification.Pipeline.ToDescriptiveString()
+compoundSpecification.ToDescriptiveString()

--- a/Documentation/Identity and Immutability.ipynb
+++ b/Documentation/Identity and Immutability.ipynb
@@ -1,17 +1,8 @@
 {
- "metadata": {
-  "kernelspec": {
-   "display_name": ".NET (C#)",
-   "language": "C#",
-   "name": ".net-csharp"
-  },
-  "language_info": {
-   "name": "C#"
-  }
- },
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Location-Specific Identity\n",
     "\n",
@@ -43,12 +34,39 @@
     "\n",
     "You can also do that in a client application using a Postgres driver.\n",
     "This code will install a driver via a NuGet package and then get the next ID from the sequence."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"dni-plaintext\">1</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "#r \"nuget: Npgsql, 5.0.7\"\n",
     "\n",
@@ -66,35 +84,11 @@
     "await conn.DisposeAsync();\n",
     "\n",
     "nextId"
-   ],
-   "outputs": [
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/html": [
-       "<div><div></div><div></div><div></div></div>"
-      ]
-     },
-     "metadata": {}
-    },
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/html": [
-       "<div class=\"dni-plaintext\">1</div>"
-      ]
-     },
-     "metadata": {}
-    }
-   ],
-   "metadata": {
-    "dotnet_interactive": {
-     "language": "csharp"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "The way that it works is that the Sequence stores a number on a hard drive. When someone asks for a number, it reads the number from the hard drive, increments it, and writes it back. It uses synchronization primitives to make sure that it only produces one number at a time. The number is stored in a location.\n",
     "\n",
@@ -107,34 +101,37 @@
     "What I prefer to do instead is to use \"location-independent identity\". That is identity which does not depend upon a certain special storage location in order to generate something unique. Location-indepedent identity lets parts of a distributed system create new objects without having to talk to each other or wait in line. It's the first step to building a system that is resilient and scalable.\n",
     "\n",
     "One kind of location-independent identity that comes to mind is the GUID: the Globally Unique Identifier. It also goes by the much more ambitious name of the UUID: Universally Unique Identifier. The universe is much bigger than the globe. Here's a GUID:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "Guid.NewGuid()"
-   ],
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
+    }
+   },
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
       "text/html": [
        "<div class=\"dni-plaintext\">98d0625c-f480-4d9c-9337-70a2f04794a2</div>"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
-   "metadata": {
-    "dotnet_interactive": {
-     "language": "csharp"
-    }
-   }
+   "source": [
+    "Guid.NewGuid()"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Any machine is capable of generating a GUID without talking to another machine or waiting in line. And it has a really good chance of being unique. That's partly to do with its structure, but mostly to do with randomness.\n",
     "\n",
@@ -143,39 +140,42 @@
     "If you want an even better guarantee of uniqueness, then you can ask for more bits of entropy. Here's one that works pretty well. Find a random number from 0 to 2^1024-1. It takes 1024 bits to express this number. Then check to see if it is prime. If not, find a different random number. The number of primes less than N is about the square root of N, and taking the square root cuts the number of bits in half. So your 1024-bit number actually only has 512 bits of entropy.\n",
     "\n",
     "Once you have your 1024-bit prime, find a second one. Multiply these together to get a 2048-bit number. This number will have 1024 bits of entropy. That's a lot more than the 128 (or more like 124) bits of entropy in a GUID. Here's what a number like that looks like:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "using System.Security.Cryptography;\r\n",
-    "\r\n",
-    "var rsa = RSA.Create(2048);\r\n",
-    "byte[] bytes = rsa.ExportRSAPublicKey();\r\n",
-    "string publicKey = Convert.ToBase64String(bytes);\r\n",
-    "publicKey"
-   ],
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
+    }
+   },
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
       "text/plain": [
        "MIIBCgKCAQEAtfzCjGf695r+Hz7H3XNNYZjG3By837mvJziRnZeovZgrCPf/I9bkSBAtjvxikjqD5EKxryisaqv5AncoY7fdn3LDxf5/HrdZcPV6GyTHkQAlIO8/dzVcvIzfRoP7qWROXGhBinTPNGUW65/0HItikM0s2AvaUah31XKnKq0b/WUAdAlVuy0EqhT83iBoX3HzlsaPsoHl/VDKZlgqEW2PkrrfbcUBwqZ5xFtK4TlYyvYzvzQ77qtKtq8mCgPY/jR+0sFl129jys7/Vg+nuKPro8Kk5E1WCknw1N8cCGZWQfvJkbN/AZCQDM4r/z45n4UdrIH71Lou88q3CxNN9sj4IQIDAQAB"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
-   "metadata": {
-    "dotnet_interactive": {
-     "language": "csharp"
-    }
-   }
+   "source": [
+    "using System.Security.Cryptography;\n",
+    "\n",
+    "var rsa = RSA.Create(2048);\n",
+    "byte[] bytes = rsa.ExportRSAPublicKey();\n",
+    "string publicKey = Convert.ToBase64String(bytes);\n",
+    "publicKey"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "That number is written in base 64, which has 64 digits as opposed to hexadecimal's 16. It takes 6 bits to write a number between 0 and 63. To write just the product of the two primes would take 2048/6 = 341 digits, but this representation takes 360 digits. Some of them encode other values that are used together with the 2048 bit product. The MIIBCgKCAQEA at the beginning and AQAB at the end are very predictable.\n",
     "\n",
@@ -184,66 +184,72 @@
     "# Identity of a Person\n",
     "\n",
     "It turns out that signing documents and decrypting messages are two things that people really like to do. So we will use a 2048-bit product of two prime numbers as the location-independent identity of a person."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "record Person(string publicKey);\n",
-    "\n",
-    "new Person(publicKey)"
-   ],
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
+    }
+   },
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
       "text/html": [
        "<table><thead><tr><th>publicKey</th></tr></thead><tbody><tr><td><div class=\"dni-plaintext\">MIIBCgKCAQEAtfzCjGf695r+Hz7H3XNNYZjG3By837mvJziRnZeovZgrCPf/I9bkSBAtjvxikjqD5EKxryisaqv5AncoY7fdn3LDxf5/HrdZcPV6GyTHkQAlIO8/dzVcvIzfRoP7qWROXGhBinTPNGUW65/0HItikM0s2AvaUah31XKnKq0b/WUAdAlVuy0EqhT83iBoX3HzlsaPsoHl/VDKZlgqEW2PkrrfbcUBwqZ5xFtK4TlYyvYzvzQ77qtKtq8mCgPY/jR+0sFl129jys7/Vg+nuKPro8Kk5E1WCknw1N8cCGZWQfvJkbN/AZCQDM4r/z45n4UdrIH71Lou88q3CxNN9sj4IQIDAQAB</div></td></tr></tbody></table>"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
-   "metadata": {
-    "dotnet_interactive": {
-     "language": "csharp"
-    }
-   }
+   "source": [
+    "record Person(string publicKey);\n",
+    "\n",
+    "new Person(publicKey)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Here we're taking advantage of a new C# construct called a _record_. A record is a class that is immutable by default. That means that the fields can't change. By deciding that the fields can't change, C# can implement Equals and GetHashCode based on those fields. Two people with the same public key must be the same person."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "new Person(publicKey).Equals(new Person(publicKey))"
-   ],
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
+    }
+   },
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
       "text/html": [
        "<div class=\"dni-plaintext\">True</div>"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
-   "metadata": {
-    "dotnet_interactive": {
-     "language": "csharp"
-    }
-   }
+   "source": [
+    "new Person(publicKey).Equals(new Person(publicKey))"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Simulating Mutability\n",
     "\n",
@@ -251,32 +257,43 @@
     "But we don't put that person's name in the Person record.\n",
     "The reason is that we want to preserve the immutability of records.\n",
     "So instead, we will define a new record that holds the person's name."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "record PersonName(Person person, string value);"
-   ],
-   "outputs": [],
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "record PersonName(Person person, string value);"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Now we can keep records of people and their names."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
+    }
+   },
+   "outputs": [],
    "source": [
     "var recordsOfTypePerson = new HashSet<Person>();\n",
     "var recordsOfTypePersonName = new HashSet<PersonName>();\n",
@@ -284,32 +301,26 @@
     "var george = new Person(publicKey);\n",
     "recordsOfTypePerson.Add(george);\n",
     "recordsOfTypePersonName.Add(new PersonName(george, \"George\"));"
-   ],
-   "outputs": [],
-   "metadata": {
-    "dotnet_interactive": {
-     "language": "csharp"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "To find a person's name, we can just search the collection of records."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "var georgesName =\n",
-    "    from personName in recordsOfTypePersonName\n",
-    "    where personName.person.Equals(george)\n",
-    "    select personName;\n",
-    "\n",
-    "georgesName.Single().value"
-   ],
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -321,13 +332,26 @@
      "output_type": "display_data"
     }
    ],
-   "metadata": {
-    "dotnet_interactive": {
-     "language": "csharp"
-    }
-   }
+   "source": [
+    "var georgesName =\n",
+    "    from personName in recordsOfTypePersonName\n",
+    "    where personName.person.Equals(george)\n",
+    "    select personName;\n",
+    "\n",
+    "georgesName.Single().value"
+   ]
   }
  ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "name": "C#"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 2
 }

--- a/Documentation/Jinaga Modeling.ipynb
+++ b/Documentation/Jinaga Modeling.ipynb
@@ -15,6 +15,9 @@
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
     }
    },
    "outputs": [
@@ -52,6 +55,9 @@
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
     }
    },
    "outputs": [
@@ -80,6 +86,9 @@
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
     }
    },
    "outputs": [
@@ -183,6 +192,9 @@
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
     }
    },
    "outputs": [

--- a/Documentation/NestedSpecifications.dib
+++ b/Documentation/NestedSpecifications.dib
@@ -35,12 +35,11 @@ var peopleInFamily = Given<Family>.Match((family, facts) =>
     select new
     {
         Person = person,
-        Names = facts.All(person, namesOfPerson)
+        Names = facts.Observable(person, namesOfPerson)
     }
 );
 
-peopleInFamily.Pipeline.ToDescriptiveString() +
-peopleInFamily.Projection.ToDescriptiveString()
+peopleInFamily.ToDescriptiveString()
 
 #!csharp
 

--- a/Documentation/Rosetta Stone.ipynb
+++ b/Documentation/Rosetta Stone.ipynb
@@ -6,6 +6,9 @@
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
     }
    },
    "outputs": [
@@ -29,6 +32,9 @@
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
     }
    },
    "outputs": [],
@@ -91,6 +97,9 @@
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
     }
    },
    "outputs": [],
@@ -120,6 +129,9 @@
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
     }
    },
    "outputs": [

--- a/Jinaga.Android/SampleApp.Android/Resources/Resource.designer.cs
+++ b/Jinaga.Android/SampleApp.Android/Resources/Resource.designer.cs
@@ -14,7 +14,7 @@ namespace SampleApp.Android
 {
 	
 	
-	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "12.2.4.160")]
+	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "13.0.0.73")]
 	public partial class Resource
 	{
 		

--- a/Jinaga.Test/MultiProjectionTest.cs
+++ b/Jinaga.Test/MultiProjectionTest.cs
@@ -47,7 +47,7 @@ namespace Jinaga.Test
                 select new YardData
                 (
                     yard,
-                    facts.All(yard, AddressesOfYard())
+                    facts.Observable(yard, AddressesOfYard())
                 )
             );
         }
@@ -61,8 +61,8 @@ namespace Jinaga.Test
                 select new ClientData
                 (
                     client,
-                    facts.All(client, NamesOfClient()),
-                    facts.All(client, ClientYards())
+                    facts.Observable(client, NamesOfClient()),
+                    facts.Observable(client, ClientYards())
                 )
             );
         }
@@ -126,9 +126,9 @@ namespace Jinaga.Test
                 select new
                 {
                     yard,
-                    yardAddresses = facts.All(yard, specifications.addressesOfYard),
+                    yardAddresses = facts.Observable(yard, specifications.addressesOfYard),
                     yard.client,
-                    clientNames = facts.All(yard.client, specifications.namesOfClient)
+                    clientNames = facts.Observable(yard.client, specifications.namesOfClient)
                 }
             );
 

--- a/Jinaga.Test/NestedWatchTest.cs
+++ b/Jinaga.Test/NestedWatchTest.cs
@@ -298,7 +298,7 @@ namespace Jinaga.Test
                 {
                     OfficeId = 1,
                     City = "Dallas",
-                    Name = null
+                    Name = ""
                 }
             });
 
@@ -478,7 +478,7 @@ namespace Jinaga.Test
                 {
                     OfficeId = 1,
                     City = "Dallas",
-                    Name = null
+                    Name = ""
                 }
             });
 

--- a/Jinaga.Test/NestedWatchTest.cs
+++ b/Jinaga.Test/NestedWatchTest.cs
@@ -291,8 +291,8 @@ namespace Jinaga.Test
             select new OfficeProjection
             {
                 Office = office,
-                Names = facts.All(office, namesOfOffice),
-                Headcounts = facts.All(office, headcountsOfOffice)
+                Names = facts.Observable(office, namesOfOffice),
+                Headcounts = facts.Observable(office, headcountsOfOffice)
             }
         );
 
@@ -311,7 +311,7 @@ namespace Jinaga.Test
             select new ManagerProjection
             {
                 Manager = manager,
-                Names = facts.All(manager, managerNames)
+                Names = facts.Observable(manager, managerNames)
             }
         );
 
@@ -323,7 +323,7 @@ namespace Jinaga.Test
             select new ManagementProjection
             {
                 Office = office,
-                Managers = facts.All(office, managersInOffice)
+                Managers = facts.Observable(office, managersInOffice)
             }
         );
     }

--- a/Jinaga.Test/Pipelines/InverseTest.cs
+++ b/Jinaga.Test/Pipelines/InverseTest.cs
@@ -77,7 +77,7 @@ namespace Jinaga.Test.Pipelines
                 select new
                 {
                     Office = office,
-                    Names = facts.All(office, namesOfOffice)
+                    Names = facts.Observable(office, namesOfOffice)
                 }
             );
 
@@ -124,7 +124,7 @@ namespace Jinaga.Test.Pipelines
                 select new
                 {
                     Office = office,
-                    Names = facts.All(office, namesOfOffice)
+                    Names = facts.Observable(office, namesOfOffice)
                 }
             );
 

--- a/Jinaga.Test/Pipelines/ProjectionTest.cs
+++ b/Jinaga.Test/Pipelines/ProjectionTest.cs
@@ -57,7 +57,7 @@ namespace Jinaga.Test.Pipelines
                 select new
                 {
                     passenger,
-                    names = facts.All(passenger, namesOfPassenger)
+                    names = facts.Observable(passenger, namesOfPassenger)
                 }
             );
 
@@ -119,7 +119,7 @@ namespace Jinaga.Test.Pipelines
                 select new
                 {
                     passenger,
-                    names = facts.All(
+                    names = facts.Observable(
                         from passengerName in facts.OfType<PassengerName>()
                         where passengerName.passenger == passenger
                         where !(

--- a/Jinaga.Test/ProjectionTest.cs
+++ b/Jinaga.Test/ProjectionTest.cs
@@ -43,7 +43,7 @@ namespace Jinaga.Test
                 select new
                 {
                     passenger,
-                    names = facts.All(passenger, namesOfPassenger)
+                    names = facts.Observable(passenger, namesOfPassenger)
                 }
             ));
 
@@ -65,7 +65,7 @@ namespace Jinaga.Test
                 where passenger.airline == airline
                 select new PassengerProjection(
                     passenger,
-                    facts.All(passenger, namesOfPassenger)
+                    facts.Observable(passenger, namesOfPassenger)
                 )
             ));
 

--- a/Jinaga.Test/QueryTest.cs
+++ b/Jinaga.Test/QueryTest.cs
@@ -170,7 +170,7 @@ namespace Jinaga.Test
                 select new
                 {
                     postCreatedAt = post.createdAt,
-                    titles = facts.All(post, postTitles)
+                    titles = facts.Observable(post, postTitles)
                 }
             );
 
@@ -235,7 +235,7 @@ namespace Jinaga.Test
                 select new
                 {
                     postCreatedAt = post.createdAt,
-                    titles = facts.All(
+                    titles = facts.Observable(
                         from title in facts.OfType<Title>()
                         where title.post == post
                         select title.value

--- a/Jinaga.Test/QueryTest.cs
+++ b/Jinaga.Test/QueryTest.cs
@@ -221,6 +221,34 @@ namespace Jinaga.Test
             subject.siteName.Should().Be("michaelperry.net");
             subject.postCreatedAt.Should().Be("2022-09-30T13:40:00Z");
         }
+
+        [Fact]
+        public async Task Query_InlineCollectionProjection()
+        {
+            var site = await j.Fact(new Site("michaelperry.net"));
+            var post = await j.Fact(new Post(site, "2022-09-30T13:40:00Z"));
+            var title = await j.Fact(new Title(post, "Introduction to Jinaga Replicator", new Title[0]));
+
+            var specification = Given<Site>.Match((site, facts) =>
+                from post in facts.OfType<Post>()
+                where post.site == site
+                select new
+                {
+                    postCreatedAt = post.createdAt,
+                    titles = facts.All(
+                        from title in facts.OfType<Title>()
+                        where title.post == post
+                        select title.value
+                    )
+                }
+            );
+
+            var posts = await j.Query(site, specification);
+
+            posts.Should().ContainSingle().Which
+                .titles.Should().ContainSingle().Which
+                    .Should().Be("Introduction to Jinaga Replicator");
+        }
     }
 
     [FactType("Blog.Site")]

--- a/Jinaga/DefaultImplementations/LocalNetwork.cs
+++ b/Jinaga/DefaultImplementations/LocalNetwork.cs
@@ -1,0 +1,32 @@
+﻿using Jinaga.Facts;
+using Jinaga.Projections;
+using Jinaga.Services;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jinaga.DefaultImplementations
+{
+    public class LocalNetwork : INetwork
+    {
+        public Task<ImmutableList<string>> Feeds(ImmutableList<FactReference> startReferences, Specification specification, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(ImmutableList<string>.Empty);
+        }
+
+        public Task<(ImmutableList<FactReference> references, string bookmark)> FetchFeed(string feed, string bookmark, CancellationToken cancellationToken)
+        {
+            return Task.FromResult((ImmutableList<FactReference>.Empty, bookmark));
+        }
+
+        public Task<FactGraph> Load(ImmutableList<FactReference> factReferences, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(FactGraph.Empty);
+        }
+
+        public Task Save(ImmutableList<Fact> facts, CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Jinaga/Facts/Fact.cs
+++ b/Jinaga/Facts/Fact.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 
 namespace Jinaga.Facts
@@ -147,12 +148,17 @@ namespace Jinaga.Facts
             return result;
         }
 
+        private static JsonSerializerOptions RelaxedStringOptions = new JsonSerializerOptions
+        {
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+        };
+
         private static string SerializeFieldValue(FieldValue value)
         {
             switch (value)
             {
                 case FieldValueString str:
-                    return JsonSerializer.Serialize(str.StringValue);
+                    return JsonSerializer.Serialize(str.StringValue, RelaxedStringOptions);
                 case FieldValueNumber number:
                     return JsonSerializer.Serialize(number.DoubleValue);
                 default:

--- a/Jinaga/Generators/SpecificationGenerator.cs
+++ b/Jinaga/Generators/SpecificationGenerator.cs
@@ -30,8 +30,8 @@ namespace Jinaga.Generators
             else if (value is SymbolValueCollection collectionValue)
             {
                 return new CollectionProjection(
-                    collectionValue.Specification.Matches,
-                    collectionValue.Specification.Projection);
+                    collectionValue.Matches,
+                    collectionValue.Projection);
             }
             else if (value is SymbolValueField field)
             {

--- a/Jinaga/Http/HttpConnection.cs
+++ b/Jinaga/Http/HttpConnection.cs
@@ -13,7 +13,11 @@ namespace Jinaga.Http
         public HttpConnection(Uri baseUrl, string token)
         {
             this.httpClient = new HttpClient();
-            
+
+            if (!baseUrl.AbsoluteUri.EndsWith("/"))
+            {
+                baseUrl = new Uri(baseUrl.AbsoluteUri + "/");
+            }
             httpClient.BaseAddress = baseUrl;
             if (!string.IsNullOrEmpty(token))
             {

--- a/Jinaga/Jinaga.cs
+++ b/Jinaga/Jinaga.cs
@@ -138,8 +138,9 @@ namespace Jinaga
             var graph = factManager.Serialize(start);
             var startReference = graph.Last;
             var projection = specification.Projection;
-            var observation = new FunctionObservation<TProjection>(added);
-            var observer = new Observer<TProjection>(specification, Product.Empty.With(specification.Given.First().Name, new SimpleElement(startReference)), factManager, observation);
+            var initialAnchor = Product.Empty.With(specification.Given.First().Name, new SimpleElement(startReference));
+            var observation = new FunctionObservation<TProjection>(initialAnchor, added);
+            var observer = new Observer<TProjection>(specification, initialAnchor, factManager, observation);
             factManager.AddObserver(observer);
             observer.Start();
             return observer;

--- a/Jinaga/JinagaClient.cs
+++ b/Jinaga/JinagaClient.cs
@@ -1,15 +1,49 @@
-﻿using Jinaga.Http;
+﻿using Jinaga.DefaultImplementations;
+using Jinaga.Http;
+using Jinaga.Services;
 using Jinaga.Storage;
 using System;
 
 namespace Jinaga
 {
+    public class JinagaClientOptions
+    {
+        /// <summary>
+        /// http://localhost:8080/jinaga/
+        /// </summary>
+        public static Uri DefaultReplicatorEndpoint = new Uri("http://localhost:8080/jinaga/");
+        
+        /// <summary>
+        /// The endpoint of the Jinaga server, or null for local operation.
+        /// </summary>
+        public Uri? HttpEndpoint { get; set; }
+    }
+    
     public static class JinagaClient
     {
+        /// <summary>
+        /// Creates a Jinaga client with no persistent storage or network connection.
+        /// </summary>
+        /// <returns>A Jinaga client</returns>
         public static Jinaga Create()
         {
-            Uri baseUrl = new Uri("http://localhost:8080/jinaga/");
-            return new Jinaga(new MemoryStore(), new HttpNetwork(baseUrl));
+            return Create(_ => { });
+        }
+        
+        /// <summary>
+        /// Creates a Jinaga client using the provided configuration.
+        /// </summary>
+        /// <param name="configure">Lambda that sets properties on the options object.</param>
+        /// <returns>A Jinaga client</returns>
+        public static Jinaga Create(Action<JinagaClientOptions> configure)
+        {
+            var options = new JinagaClientOptions();
+            configure(options);
+            IStore store = new MemoryStore();
+            INetwork network = options.HttpEndpoint == null
+                ? (INetwork)new LocalNetwork()
+                : new HttpNetwork(options.HttpEndpoint);
+            return new Jinaga(store, network);
         }
     }
 }

--- a/Jinaga/Managers/Deserializer.cs
+++ b/Jinaga/Managers/Deserializer.cs
@@ -215,6 +215,34 @@ namespace Jinaga.Managers
                     return WatchedObservableCollection.Create(elementType, product.GetAnchor(), parameterName, emitter.WatchContext);
                 }
             }
+            else if (parameterType.IsGenericType &&
+                parameterType.GetGenericTypeDefinition() == typeof(IQueryable<>))
+            {
+                var elementType = parameterType.GetGenericArguments()[0];
+                if (elementType.IsFactType())
+                {
+                    var elements = Projector.GetFactReferences(projection, product, parameterName)
+                        .Select(reference => emitter.DeserializeToType(reference, elementType))
+                        .ToImmutableList();
+                    return CreateQueryable(elementType, elements);
+                }
+                else
+                {
+                    var collectionProjection = (CollectionProjection)projection;
+                    var collectionElement = (CollectionElement)product.GetElement(parameterName);
+                    var elements = Deserialize(
+                            emitter,
+                            collectionProjection.Projection,
+                            elementType,
+                            collectionElement.Products,
+                            product.GetAnchor(),
+                            parameterName
+                        )
+                        .Select(p => p.Projection)
+                        .ToImmutableList();
+                    return CreateQueryable(elementType, elements);
+                }
+            }
             else if (projection is FieldProjection fieldProjection)
             {
                 var reference = product.GetFactReference(fieldProjection.Tag);
@@ -279,6 +307,20 @@ namespace Jinaga.Managers
             {
                 throw new NotImplementedException();
             }
+        }
+
+        private static object CreateQueryable(Type elementType, ImmutableList<object> elements)
+        {
+            var test = elements.AsQueryable();
+            var method = typeof(Deserializer)
+                .GetMethod(nameof(CreateQueryableGeneric), BindingFlags.NonPublic | BindingFlags.Static)
+                .MakeGenericMethod(elementType);
+            return method.Invoke(null, new[] { elements });
+        }
+
+        private static IQueryable<T> CreateQueryableGeneric<T>(ImmutableList<object> elements)
+        {
+            return elements.OfType<T>().AsQueryable();
         }
     }
 }

--- a/Jinaga/Managers/Deserializer.cs
+++ b/Jinaga/Managers/Deserializer.cs
@@ -226,7 +226,7 @@ namespace Jinaga.Managers
                         .ToImmutableList();
                     return CreateQueryable(elementType, elements);
                 }
-                else
+                else if (product.Contains(parameterName))
                 {
                     var collectionProjection = (CollectionProjection)projection;
                     var collectionElement = (CollectionElement)product.GetElement(parameterName);
@@ -241,6 +241,10 @@ namespace Jinaga.Managers
                         .Select(p => p.Projection)
                         .ToImmutableList();
                     return CreateQueryable(elementType, elements);
+                }
+                else
+                {
+                    return CreateQueryable(elementType, ImmutableList<object>.Empty);
                 }
             }
             else if (projection is FieldProjection fieldProjection)

--- a/Jinaga/Observer.cs
+++ b/Jinaga/Observer.cs
@@ -159,13 +159,15 @@ namespace Jinaga
         private static Type GetCollectionType(Type type, string collectionName)
         {
             var propertyType = type.GetProperty(collectionName).PropertyType;
-            if (propertyType.IsGenericType && propertyType.GetGenericTypeDefinition() == typeof(IObservableCollection<>))
+            if (propertyType.IsGenericType &&
+                (propertyType.GetGenericTypeDefinition() == typeof(IObservableCollection<>) ||
+                 propertyType.GetGenericTypeDefinition() == typeof(IQueryable<>)))
             {
                 return propertyType.GetGenericArguments()[0];
             }
             else
             {
-                throw new InvalidOperationException($"Collection {collectionName} is not an IObservableCollection");
+                throw new InvalidOperationException($"Collection {collectionName} is not an IObservableCollection or IQueryable");
             }
         }
     }

--- a/Jinaga/Observers/FunctionObservation.cs
+++ b/Jinaga/Observers/FunctionObservation.cs
@@ -10,11 +10,13 @@ namespace Jinaga.Observers
 {
     public class FunctionObservation<TProjection> : IObservation
     {
+        private readonly Product initialAnchor;
         private readonly Func<TProjection, Task<Func<Task>>> added;
         private ImmutableList<AddedHandler> addedHandlers = ImmutableList<AddedHandler>.Empty;
 
-        public FunctionObservation(Func<TProjection, Task<Func<Task>>> added)
+        public FunctionObservation(Product initialAnchor, Func<TProjection, Task<Func<Task>>> added)
         {
+            this.initialAnchor = initialAnchor;
             this.added = added;
         }
 
@@ -51,7 +53,7 @@ namespace Jinaga.Observers
                     }
                 }
             }
-            else
+            else if (initialAnchor.Equals(anchor))
             {
                 var removal = await added((TProjection)projection);
                 removals = removals.Add(new KeyValuePair<Product, Func<Task>>(product.GetAnchor(), removal));

--- a/Jinaga/Parsers/SymbolValueCollection.cs
+++ b/Jinaga/Parsers/SymbolValueCollection.cs
@@ -1,17 +1,18 @@
 using Jinaga.Definitions;
 using Jinaga.Projections;
+using System.Collections.Immutable;
 
 namespace Jinaga.Parsers
 {
     public class SymbolValueCollection : SymbolValue
     {
-        public SetDefinition StartSetDefinition { get; }
-        public Specification Specification { get; }
+        public ImmutableList<Match> Matches { get; }
+        public Projection Projection { get; }
 
-        public SymbolValueCollection(SetDefinition startSetDefinition, Specification specification)
+        public SymbolValueCollection(ImmutableList<Match> matches, Projection projection)
         {
-            StartSetDefinition = startSetDefinition;
-            Specification = specification;
+            Matches = matches;
+            Projection = projection;
         }
     }
 }

--- a/Jinaga/Parsers/ValueParser.cs
+++ b/Jinaga/Parsers/ValueParser.cs
@@ -1,6 +1,5 @@
 using Jinaga.Definitions;
 using Jinaga.Generators;
-using Jinaga.Pipelines;
 using Jinaga.Projections;
 using Jinaga.Repository;
 using Jinaga.Visualizers;

--- a/Jinaga/Parsers/ValueParser.cs
+++ b/Jinaga/Parsers/ValueParser.cs
@@ -77,17 +77,17 @@ namespace Jinaga.Parsers
                 var setDefinition = new SetDefinitionInitial(variable.Label, variable.Type);
                 return (new SymbolValueSetDefinition(setDefinition), variable.Label.Name);
             }
-            else if (expression is MethodCallExpression allCallExpression &&
-                allCallExpression.Method.DeclaringType == typeof(FactRepository) &&
-                allCallExpression.Method.Name == nameof(FactRepository.Observable) &&
-                allCallExpression.Arguments.Count == 2 &&
-                typeof(Specification).IsAssignableFrom(allCallExpression.Arguments[1].Type))
+            else if (expression is MethodCallExpression observableCallExpression &&
+                observableCallExpression.Method.DeclaringType == typeof(FactRepository) &&
+                observableCallExpression.Method.Name == nameof(FactRepository.Observable) &&
+                observableCallExpression.Arguments.Count == 2 &&
+                typeof(Specification).IsAssignableFrom(observableCallExpression.Arguments[1].Type))
             {
-                var start = ParseValue(symbolTable, context, allCallExpression.Arguments[0]).symbolValue;
+                var start = ParseValue(symbolTable, context, observableCallExpression.Arguments[0]).symbolValue;
                 if (start is SymbolValueSetDefinition startValue)
                 {
                     var startSetDefinition = startValue.SetDefinition;
-                    var specification = ParseSpecification(allCallExpression.Arguments[1]);
+                    var specification = ParseSpecification(observableCallExpression.Arguments[1]);
                     var arguments = ImmutableList<Pipelines.Label>.Empty.Add(startSetDefinition.Label);
                     specification = specification.Apply(arguments);
                     return (new SymbolValueCollection(specification.Matches, specification.Projection), "");
@@ -97,13 +97,13 @@ namespace Jinaga.Parsers
                     throw new NotImplementedException($"ParseValue: {ExpressionVisualizer.DumpExpression(expression)}");
                 }
             }
-            else if (expression is MethodCallExpression allIQueryableCallExpression &&
-                allIQueryableCallExpression.Method.DeclaringType == typeof(FactRepository) &&
-                allIQueryableCallExpression.Method.Name == nameof(FactRepository.Observable) &&
-                allIQueryableCallExpression.Arguments.Count == 1 &&
-                typeof(IQueryable).IsAssignableFrom(allIQueryableCallExpression.Arguments[0].Type))
+            else if (expression is MethodCallExpression observableIQueryableCallExpression &&
+                observableIQueryableCallExpression.Method.DeclaringType == typeof(FactRepository) &&
+                observableIQueryableCallExpression.Method.Name == nameof(FactRepository.Observable) &&
+                observableIQueryableCallExpression.Arguments.Count == 1 &&
+                typeof(IQueryable).IsAssignableFrom(observableIQueryableCallExpression.Arguments[0].Type))
             {
-                var result = SpecificationParser.ParseSpecification(symbolTable, context, allIQueryableCallExpression.Arguments[0]);
+                var result = SpecificationParser.ParseSpecification(symbolTable, context, observableIQueryableCallExpression.Arguments[0]);
                 var matches = SpecificationGenerator.CreateMatches(context, result);
                 var projection = SpecificationGenerator.CreateProjection(result.SymbolValue);
                 return (new SymbolValueCollection(matches, projection), "");

--- a/Jinaga/Parsers/ValueParser.cs
+++ b/Jinaga/Parsers/ValueParser.cs
@@ -109,6 +109,13 @@ namespace Jinaga.Parsers
                 var projection = SpecificationGenerator.CreateProjection(result.SymbolValue);
                 return (new SymbolValueCollection(matches, projection), "");
             }
+            else if (typeof(IQueryable).IsAssignableFrom(expression.Type))
+            {
+                var result = SpecificationParser.ParseSpecification(symbolTable, context, expression);
+                var matches = SpecificationGenerator.CreateMatches(context, result);
+                var projection = SpecificationGenerator.CreateProjection(result.SymbolValue);
+                return (new SymbolValueCollection(matches, projection), "");
+            }
             else
             {
                 throw new NotImplementedException($"ParseValue: {ExpressionVisualizer.DumpExpression(expression)}");

--- a/Jinaga/Parsers/ValueParser.cs
+++ b/Jinaga/Parsers/ValueParser.cs
@@ -80,7 +80,7 @@ namespace Jinaga.Parsers
             }
             else if (expression is MethodCallExpression allCallExpression &&
                 allCallExpression.Method.DeclaringType == typeof(FactRepository) &&
-                allCallExpression.Method.Name == nameof(FactRepository.All) &&
+                allCallExpression.Method.Name == nameof(FactRepository.Observable) &&
                 allCallExpression.Arguments.Count == 2 &&
                 typeof(Specification).IsAssignableFrom(allCallExpression.Arguments[1].Type))
             {
@@ -100,7 +100,7 @@ namespace Jinaga.Parsers
             }
             else if (expression is MethodCallExpression allIQueryableCallExpression &&
                 allIQueryableCallExpression.Method.DeclaringType == typeof(FactRepository) &&
-                allIQueryableCallExpression.Method.Name == nameof(FactRepository.All) &&
+                allIQueryableCallExpression.Method.Name == nameof(FactRepository.Observable) &&
                 allIQueryableCallExpression.Arguments.Count == 1 &&
                 typeof(IQueryable).IsAssignableFrom(allIQueryableCallExpression.Arguments[0].Type))
             {

--- a/Jinaga/Products/Product.cs
+++ b/Jinaga/Products/Product.cs
@@ -19,7 +19,19 @@ namespace Jinaga.Products
 
         public IEnumerable<string> Names => elements.Keys;
 
-        public Element GetElement(string name) => elements[name];
+        public bool Contains(string name) => elements.ContainsKey(name);
+
+        public Element GetElement(string name)
+        {
+            if (elements.TryGetValue(name, out var element))
+            {
+                return element;
+            }
+            else
+            {
+                throw new ArgumentException($"The product {this} does not contain an element named {name}.");
+            }
+        }
 
         public FactReference GetFactReference(string name)
         {
@@ -79,6 +91,12 @@ namespace Jinaga.Products
             var theseReferences = this.elements
                 .Select(pair => ComparablePair.From(pair.Key, pair.Value));
             return theseReferences.SetHash();
+        }
+
+        public override string ToString()
+        {
+            var names = string.Join(", ", elements.Keys);
+            return $"({names})";
         }
     }
 }

--- a/Jinaga/Repository/FactRepository.cs
+++ b/Jinaga/Repository/FactRepository.cs
@@ -31,5 +31,10 @@ namespace Jinaga.Repository
         {
             throw new NotImplementedException();
         }
+
+        public IObservableCollection<TProjection> All<TProjection>(IQueryable<TProjection> queryable)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Jinaga/Repository/FactRepository.cs
+++ b/Jinaga/Repository/FactRepository.cs
@@ -25,14 +25,14 @@ namespace Jinaga.Repository
             return this.OfType<TFact>().Where(predicate);
         }
 
-        public IObservableCollection<TProjection> All<TFact, TProjection>(
+        public IObservableCollection<TProjection> Observable<TFact, TProjection>(
             TFact start,
             Specification<TFact, TProjection> specification)
         {
             throw new NotImplementedException();
         }
 
-        public IObservableCollection<TProjection> All<TProjection>(IQueryable<TProjection> queryable)
+        public IObservableCollection<TProjection> Observable<TProjection>(IQueryable<TProjection> queryable)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
Declare collections without the need for a separate specification. Use the IQueryable directly in facts.Observable to create an observable collection. Or use the IQueryable without facts.Observable to create a snapshot.