### PR TITLE
Fix transparent identifier issue

### DIFF
--- a/Jinaga.Test/Pipelines/ProjectionTest.cs
+++ b/Jinaga.Test/Pipelines/ProjectionTest.cs
@@ -194,5 +194,25 @@ namespace Jinaga.Test.Pipelines
 ";
             passengers.ToDescriptiveString().Should().Be(expected.Replace("\r", ""));
         }
+
+        [Fact]
+        public void Projection_CanHaveMultipleStages()
+        {
+            var attendanceSpecification = Given<Airline>.Match((airline, facts) =>
+                from airlineDay in facts.OfType<AirlineDay>()
+                where airlineDay.airline == airline
+                from flight in facts.OfType<Flight>()
+                where flight.airlineDay == airlineDay
+                select new
+                {
+                    refunds =
+                        from booking in facts.OfType<Booking>()
+                        where booking.flight == flight
+                        from refund in facts.OfType<Refund>()
+                        where refund.booking == booking
+                        select refund
+                }
+            );
+        }
     }
 }

--- a/Jinaga/Definitions/SymbolTable.cs
+++ b/Jinaga/Definitions/SymbolTable.cs
@@ -22,14 +22,26 @@ namespace Jinaga.Definitions
             }
             else
             {
-                var symbolNames = string.Join(", ", symbols.Select(s => s.Key).ToArray());
-                throw new ArgumentException($"The symbol table does not contain a member named {name}: {symbolNames}");
+                throw new ArgumentException($"The symbol table {this} does not contain a member named {name}.");
             }
         }
 
         public SymbolTable With(string name, SymbolValue value)
         {
-            return new SymbolTable(this.symbols.Add(name, value));
+            if (symbols.ContainsKey(name))
+            {
+                throw new ArgumentException($"The symbol table {this} already contains a member named {name}.");
+            }
+            else
+            {
+                return new SymbolTable(symbols.Add(name, value));
+            }
+        }
+
+        public override string ToString()
+        {
+            var symbolNames = string.Join(", ", symbols.Select(s => s.Key).ToArray());
+            return $"({symbolNames})";
         }
     }
 }

--- a/Jinaga/Definitions/SymbolTable.cs
+++ b/Jinaga/Definitions/SymbolTable.cs
@@ -28,14 +28,7 @@ namespace Jinaga.Definitions
 
         public SymbolTable With(string name, SymbolValue value)
         {
-            if (symbols.ContainsKey(name))
-            {
-                throw new ArgumentException($"The symbol table {this} already contains a member named {name}.");
-            }
-            else
-            {
-                return new SymbolTable(symbols.Add(name, value));
-            }
+            return new SymbolTable(symbols.SetItem(name, value));
         }
 
         public override string ToString()


### PR DESCRIPTION
When the specification has two matches and a projection with two matches,
the parser throws an exception. The symbol table already contains the name
<>transparentIdentifier0.
