### PR TITLE
topological order

### DIFF
--- a/Jinaga.Test/Facts/FactGraphBuilderTest.cs
+++ b/Jinaga.Test/Facts/FactGraphBuilderTest.cs
@@ -58,5 +58,29 @@ namespace Jinaga.Test.Facts
             Assert.Equal("Test.Root", factGraph.GetFact(factGraph.FactReferences[0]).Reference.Type);
             Assert.Equal("Test.Successor", factGraph.GetFact(factGraph.FactReferences[1]).Reference.Type);
         }
+
+        [Fact]
+        public void Builder_OutOfOrder()
+        {
+            var builder = new FactGraphBuilder();
+            builder.Add(Fact.Create(
+                "Test.Successor",
+                ImmutableList.Create(
+                    new Field("identifier",
+                        new FieldValueString("testsuccessor"))),
+                ImmutableList.Create(
+                    (Predecessor)new PredecessorSingle("root",
+                        new FactReference("Test.Root", "52bexk3CJadZJk31WH3KhvQAGr6CNHLdGIL+0vW7auWFznhfcpE/FKAQgC7syq+4aP78XgWhhJUevNoYyC25BA==")))));
+            builder.Add(Fact.Create(
+                "Test.Root",
+                ImmutableList.Create(
+                    new Field("identifier",
+                        new FieldValueString("testroot"))),
+                ImmutableList<Predecessor>.Empty));
+            var factGraph = builder.Build();
+            Assert.Equal(2, factGraph.FactReferences.Count);
+            Assert.Equal("Test.Root", factGraph.GetFact(factGraph.FactReferences[0]).Reference.Type);
+            Assert.Equal("Test.Successor", factGraph.GetFact(factGraph.FactReferences[1]).Reference.Type);
+        }
     }
 }

--- a/Jinaga.Test/Facts/FactGraphBuilderTest.cs
+++ b/Jinaga.Test/Facts/FactGraphBuilderTest.cs
@@ -1,0 +1,62 @@
+﻿using FluentAssertions;
+using Jinaga.Facts;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Jinaga.Test.Facts
+{
+    public class FactGraphBuilderTest
+    {
+        [Fact]
+        public void Builder_EmptyFactGraph()
+        {
+            var builder = new FactGraphBuilder();
+            var factGraph = builder.Build();
+            Assert.Empty(factGraph.FactReferences);
+        }
+
+        [Fact]
+        public void Builder_SingleFact()
+        {
+            var builder = new FactGraphBuilder();
+            builder.Add(Fact.Create(
+                "Test.Root",
+                ImmutableList.Create(
+                    new Field("identifier",
+                        new FieldValueString("testroot"))),
+                ImmutableList<Predecessor>.Empty));
+            var factGraph = builder.Build();
+            factGraph.FactReferences.Should().ContainSingle()
+                .Which.Hash.Should().Be("52bexk3CJadZJk31WH3KhvQAGr6CNHLdGIL+0vW7auWFznhfcpE/FKAQgC7syq+4aP78XgWhhJUevNoYyC25BA==");
+        }
+
+        [Fact]
+        public void Builder_InOrder()
+        {
+            var builder = new FactGraphBuilder();
+            builder.Add(Fact.Create(
+                "Test.Root",
+                ImmutableList.Create(
+                    new Field("identifier",
+                        new FieldValueString("testroot"))),
+                ImmutableList<Predecessor>.Empty));
+            builder.Add(Fact.Create(
+                "Test.Successor",
+                ImmutableList.Create(
+                    new Field("identifier",
+                        new FieldValueString("testsuccessor"))),
+                ImmutableList.Create(
+                    (Predecessor)new PredecessorSingle("root",
+                        new FactReference("Test.Root", "52bexk3CJadZJk31WH3KhvQAGr6CNHLdGIL+0vW7auWFznhfcpE/FKAQgC7syq+4aP78XgWhhJUevNoYyC25BA==")))));
+            var factGraph = builder.Build();
+            Assert.Equal(2, factGraph.FactReferences.Count);
+            Assert.Equal("Test.Root", factGraph.GetFact(factGraph.FactReferences[0]).Reference.Type);
+            Assert.Equal("Test.Successor", factGraph.GetFact(factGraph.FactReferences[1]).Reference.Type);
+        }
+    }
+}

--- a/Jinaga.Test/Facts/FactGraphBuilderTest.cs
+++ b/Jinaga.Test/Facts/FactGraphBuilderTest.cs
@@ -82,5 +82,21 @@ namespace Jinaga.Test.Facts
             Assert.Equal("Test.Root", factGraph.GetFact(factGraph.FactReferences[0]).Reference.Type);
             Assert.Equal("Test.Successor", factGraph.GetFact(factGraph.FactReferences[1]).Reference.Type);
         }
+
+        [Fact]
+        public void Buidler_Incomplete()
+        {
+            var builder = new FactGraphBuilder();
+            builder.Add(Fact.Create(
+                "Test.Successor",
+                ImmutableList.Create(
+                    new Field("identifier",
+                        new FieldValueString("testsuccessor"))),
+                ImmutableList.Create(
+                    (Predecessor)new PredecessorSingle("root",
+                        new FactReference("Test.Root", "52bexk3CJadZJk31WH3KhvQAGr6CNHLdGIL+0vW7auWFznhfcpE/FKAQgC7syq+4aP78XgWhhJUevNoYyC25BA==")))));
+            var graph = builder.Build();
+            graph.FactReferences.Should().BeEmpty();
+        }
     }
 }

--- a/Jinaga/Facts/FactGraph.cs
+++ b/Jinaga/Facts/FactGraph.cs
@@ -21,6 +21,9 @@ namespace Jinaga.Facts
             this.topologicalOrder = topologicalOrder;
         }
 
+        public bool CanAdd(Fact fact) =>
+            fact.GetAllPredecessorReferences().All(p => factsByReference.ContainsKey(p));
+
         public FactGraph Add(Fact fact)
         {
             if (factsByReference.ContainsKey(fact.Reference))
@@ -28,7 +31,7 @@ namespace Jinaga.Facts
                 return this;
             }
 
-            if (!fact.GetAllPredecessorReferences().All(p => factsByReference.ContainsKey(p)))
+            if (!CanAdd(fact))
             {
                 throw new ArgumentException("The fact graph does not contain all of the predecessors of the fact.");
             }

--- a/Jinaga/Facts/FactGraphBuilder.cs
+++ b/Jinaga/Facts/FactGraphBuilder.cs
@@ -1,0 +1,17 @@
+﻿namespace Jinaga.Facts
+{
+    public class FactGraphBuilder
+    {
+        private FactGraph factGraph = FactGraph.Empty;
+
+        public void Add(Fact fact)
+        {
+            factGraph = factGraph.Add(fact);
+        }
+        
+        public FactGraph Build()
+        {
+            return factGraph;
+        }
+    }
+}

--- a/Jinaga/Facts/FactGraphBuilder.cs
+++ b/Jinaga/Facts/FactGraphBuilder.cs
@@ -1,16 +1,40 @@
-﻿namespace Jinaga.Facts
+﻿using System.Collections.Immutable;
+using System.Linq;
+
+namespace Jinaga.Facts
 {
     public class FactGraphBuilder
     {
         private FactGraph factGraph = FactGraph.Empty;
+        private ImmutableList<Fact> reserve = ImmutableList<Fact>.Empty;
 
         public void Add(Fact fact)
         {
-            factGraph = factGraph.Add(fact);
+            if (factGraph.CanAdd(fact))
+            {
+                factGraph = factGraph.Add(fact);
+            }
+            else
+            {
+                reserve = reserve.Add(fact);
+            }
         }
         
         public FactGraph Build()
         {
+            while (reserve.Any())
+            {
+                var retry = reserve;
+                reserve = ImmutableList<Fact>.Empty;
+                foreach (var fact in retry)
+                {
+                    Add(fact);
+                }
+                if (retry.Count == reserve.Count)
+                {
+                    throw new System.Exception("The fact graph cannot be built because of a circular dependency.");
+                }
+            }
             return factGraph;
         }
     }

--- a/Jinaga/Facts/FactGraphBuilder.cs
+++ b/Jinaga/Facts/FactGraphBuilder.cs
@@ -32,7 +32,8 @@ namespace Jinaga.Facts
                 }
                 if (retry.Count == reserve.Count)
                 {
-                    throw new System.Exception("The fact graph cannot be built because of a circular dependency.");
+                    // We did the best we can.
+                    break;
                 }
             }
             return factGraph;

--- a/Jinaga/Http/HttpNetwork.cs
+++ b/Jinaga/Http/HttpNetwork.cs
@@ -56,10 +56,13 @@ namespace Jinaga.Http
                 References = factReferences.Select(r => CreateFactReference(r)).ToList()
             };
             LoadResponse response = await webClient.Load(request, cancellationToken);
-            var graph = response.Facts.Aggregate(
-                FactGraph.Empty,
-                (graph, fact) => graph.Add(ReadFact(fact)));
-            return graph;
+            var builder = new FactGraphBuilder();
+            foreach (var factRecord in response.Facts)
+            {
+                var fact = ReadFact(factRecord);
+                builder.Add(fact);
+            }
+            return builder.Build();
         }
 
         private static FactRecord CreateFactRecord(Fact fact)

--- a/Jinaga/Projections/CollectionProjection.cs
+++ b/Jinaga/Projections/CollectionProjection.cs
@@ -36,7 +36,7 @@ namespace Jinaga.Projections
             var indent = Strings.Indent(depth);
             var matchStrings = Matches.Select(match => match.ToDescriptiveString(depth + 1));
             var matchString = string.Join("", matchStrings);
-            var projectionString = Projection.ToDescriptiveString(depth + 1);
+            var projectionString = Projection.ToDescriptiveString(depth);
             return $"{{\n{matchString}{indent}}} => {projectionString}";
         }
     }

--- a/Jinaga/Storage/MemoryStore.cs
+++ b/Jinaga/Storage/MemoryStore.cs
@@ -195,11 +195,16 @@ namespace Jinaga.Storage
 
         public Task<FactGraph> Load(ImmutableList<FactReference> references, CancellationToken cancellationToken)
         {
-            var graph = references
+            var facts = references
                 .SelectMany(reference => ancestors[reference])
                 .Distinct()
-                .Select(reference => factsByReference[reference])
-                .Aggregate(FactGraph.Empty, (graph, fact) => graph.Add(fact));
+                .Select(reference => factsByReference[reference]);
+            var builder = new FactGraphBuilder();
+            foreach (var fact in facts)
+            {
+                builder.Add(fact);
+            }
+            var graph = builder.Build();
             return Task.FromResult(graph);
         }
 


### PR DESCRIPTION
Threw an exception while demonstrating ImprovingU. A course in the ImprovingU history
has a title with missing predecessors. Tolerate these errors and return a valid subset.

- Remove extra indentation in projection.
- Use the builder pattern to construct graphs.
- Reorder facts topologically
- Produce the most complete graph we can.
