### PR TITLE
Support projection classes with additional properties

### DIFF
--- a/Jinaga.Store.SQLite.Test/Fakes/FakeNetwork.cs
+++ b/Jinaga.Store.SQLite.Test/Fakes/FakeNetwork.cs
@@ -8,9 +8,9 @@ using Xunit.Abstractions;
 namespace Jinaga.Store.SQLite.Test.Fakes;
 internal class FakeFeed
 {
-    public string Name { get; set; }
-    public Fact[] Facts { get; set; }
-    public int Delay { get; set; }
+    public required string Name { get; set; }
+    public required Fact[] Facts { get; set; }
+    public required int Delay { get; set; }
 }
 internal class FakeNetwork : INetwork
 {

--- a/Jinaga.Store.SQLite.Test/Observers/WatchFromNetworkTest.cs
+++ b/Jinaga.Store.SQLite.Test/Observers/WatchFromNetworkTest.cs
@@ -149,8 +149,8 @@ public class WatchFromNetworkTest
 
     private class OfficeViewModel
     {
-        public Office Office;
-        public string Name;
+        public required Office Office;
+        public string? Name;
     }
 
     private class CompanyViewModel

--- a/Jinaga.Test/Specifications/ProjectionTest.cs
+++ b/Jinaga.Test/Specifications/ProjectionTest.cs
@@ -98,5 +98,8 @@ namespace Jinaga.Test.Specifications.Specifications
         }
     }
 
-    record PassengerProjection(Passenger Passenger, IObservableCollection<PassengerName> names);
+    record PassengerProjection(Passenger Passenger, IObservableCollection<PassengerName> names)
+    {
+        public string Name => names.Select(name => name.value).FirstOrDefault();
+    }
 }

--- a/Jinaga.Test/Specifications/ProjectionTest.cs
+++ b/Jinaga.Test/Specifications/ProjectionTest.cs
@@ -67,6 +67,9 @@ namespace Jinaga.Test.Specifications.Specifications
                     passenger,
                     facts.Observable(passenger, namesOfPassenger)
                 )
+                {
+                    PassengerID = j.Hash(passenger)
+                }
             ), airline);
 
             var result = passengers.Should().ContainSingle().Subject;
@@ -98,8 +101,10 @@ namespace Jinaga.Test.Specifications.Specifications
         }
     }
 
-    record PassengerProjection(Passenger Passenger, IObservableCollection<PassengerName> names)
+    record PassengerProjection(Passenger passenger, IObservableCollection<PassengerName> names)
     {
         public string Name => names.Select(name => name.value).FirstOrDefault();
+
+        public string PassengerID { get; internal set; }
     }
 }

--- a/Jinaga/Managers/Projector.cs
+++ b/Jinaga/Managers/Projector.cs
@@ -93,27 +93,15 @@ namespace Jinaga.Managers
             }
             else if (projection is CompoundProjection compound)
             {
-                var constructorInfos = type.GetConstructors();
-                if (constructorInfos.Length != 1)
-                {
-                    throw new NotImplementedException($"Multiple constructors for {type.Name}");
-                }
-                var constructor = constructorInfos.Single();
-                var parameters = constructor.GetParameters();
-                var properties = type.GetProperties();
-                var names = parameters.Select(parameter => parameter.Name).Concat(
-                    properties.Select(property => property.Name)
-                ).Distinct();
-                var references = (
+                return (
                     from product in products
-                    from name in names
+                    from name in compound.Names
                     from reference in GetFactReferences(
                         compound.GetProjection(name),
                         product,
                         name)
                     select reference
                 ).Distinct().ToImmutableList();
-                return references;
             }
             else if (projection is FieldProjection field)
             {

--- a/Jinaga/Projections/CompoundProjection.cs
+++ b/Jinaga/Projections/CompoundProjection.cs
@@ -31,7 +31,14 @@ namespace Jinaga.Projections
 
         public Projection GetProjection(string name)
         {
-            return projections[name];
+            if (projections.TryGetValue(name, out var projection))
+            {
+                return projection;
+            }
+            else
+            {
+                throw new ArgumentException($"No projection named {name}");
+            }
         }
 
         public override bool CanRunOnGraph => projections.Values.All(p => p.CanRunOnGraph);

--- a/Jinaga/Repository/SpecificationProcessor.cs
+++ b/Jinaga/Repository/SpecificationProcessor.cs
@@ -91,10 +91,14 @@ namespace Jinaga.Repository
             }
             else if (expression is MemberInitExpression memberInit)
             {
+                var parameters = memberInit.NewExpression.Constructor.GetParameters()
+                    .Zip(memberInit.NewExpression.Arguments, (parameter, arg) => KeyValuePair.Create(
+                        parameter.Name,
+                        ProcessProjection(arg, symbolTable)));
                 var fields = memberInit.Bindings
-                    .Select(binding => ProcessProjectionMember(binding, symbolTable))
-                    .ToImmutableDictionary();
-                var compoundProjection = new CompoundProjection(fields, memberInit.Type);
+                    .Select(binding => ProcessProjectionMember(binding, symbolTable));
+                var childProjections = parameters.Concat(fields).ToImmutableDictionary();
+                var compoundProjection = new CompoundProjection(childProjections, memberInit.Type);
                 return compoundProjection;
             }
             else if (expression is MemberExpression memberExpression)


### PR DESCRIPTION
- Add a property to duplicate the error
- Include test for property with setter
- Create projections for constructor parameters in member init expression.
- Use compound projection names to get references
- Mark properties required to fix nullability warnings
