### PR TITLE
Fix exception in Generate Existential Where Clause

### DIFF
--- a/Jinaga.Store.SQLite.Test/ExecuteInverseTest.cs
+++ b/Jinaga.Store.SQLite.Test/ExecuteInverseTest.cs
@@ -109,79 +109,79 @@ public class ExecuteInverseTest
         inverse0Sql.SqlQuery.Sql.Should().Be(
             "SELECT " +
                 "f1.hash as hash1, f1.fact_id as id1, f1.data as data1, " + // child
-                "f4.hash as hash4, f4.fact_id as id4, f4.data as data4, " + // root
-                "f5.hash as hash5, f5.fact_id as id5, f5.data as data5 " +  // source
+                "f5.hash as hash5, f5.fact_id as id5, f5.data as data5, " + // root
+                "f6.hash as hash6, f6.fact_id as id6, f6.data as data6 " +  // source
             "FROM fact f1 " +       // child
-            "JOIN edge e2 " +       // child->Parent
-                "ON e2.successor_fact_id = f1.fact_id " +
-                "AND e2.role_id = ?4 " +
-            "JOIN fact f3 " +       // Parent
-                "ON f3.fact_id = e2.predecessor_fact_id " +
-            "JOIN edge e3 " +       // Parent->Root
-                "ON e3.successor_fact_id = f3.fact_id " +
+            "JOIN edge e3 " +       // child->Parent
+                "ON e3.successor_fact_id = f1.fact_id " +
                 "AND e3.role_id = ?5 " +
-            "JOIN fact f4 " +       // root
+            "JOIN fact f4 " +       // Parent
                 "ON f4.fact_id = e3.predecessor_fact_id " +
-            "JOIN edge e4 " +       // child->Sources
-                "ON e4.successor_fact_id = f1.fact_id " +
+            "JOIN edge e4 " +       // Parent->Root
+                "ON e4.successor_fact_id = f4.fact_id " +
                 "AND e4.role_id = ?6 " +
-            "JOIN fact f5 " +       // source
+            "JOIN fact f5 " +       // root
                 "ON f5.fact_id = e4.predecessor_fact_id " +
+            "JOIN edge e5 " +       // child->Sources
+                "ON e5.successor_fact_id = f1.fact_id " +
+                "AND e5.role_id = ?7 " +
+            "JOIN fact f6 " +       // source
+                "ON f6.fact_id = e5.predecessor_fact_id " +
             "WHERE f1.fact_type_id = ?1 AND f1.hash = ?2 " +
             "AND EXISTS (" +
                 "SELECT 1 FROM edge e1 " +  // child->Parent
                 "JOIN fact f2 " +           // Parent
                     "ON f2.fact_id = e1.predecessor_fact_id " +
                 "WHERE e1.successor_fact_id = f1.fact_id " +
-                "AND e1.role_id = ?3" +
+                "AND e1.role_id = ?3 " +
                 "AND NOT EXISTS (" +
-                    "SELECT 1 FROM edge e5 " + // Parent->History
-                    "JOIN fact f6 " +          // Parent
-                        "ON f6.fact_id = e5.predecessor_fact_id " +
-                    "WHERE e5.successor_fact_id = f2.fact_id " +
-                    "AND e5.role_id = ?7" +
+                    "SELECT 1 FROM edge e2 " + // Parent->History
+                    "JOIN fact f3 " +          // Parent
+                        "ON f3.fact_id = e2.successor_fact_id " +
+                    "WHERE e2.predecessor_fact_id = f2.fact_id " +
+                    "AND e2.role_id = ?4" +
                 ")" +
             ") " +
-            "ORDER BY f4.fact_id ASC, f5.fact_id ASC"
+            "ORDER BY f5.fact_id ASC, f6.fact_id ASC"
         );
 
         var inverse1Sql = inverses[1].InverseSpecification.ToSql();
         inverse1Sql.SqlQuery.Sql.Should().Be(
             "SELECT " +
                 "f1.hash as hash1, f1.fact_id as id1, f1.data as data1, " + // x: Parent
-                "f2.hash as hash2, f2.fact_id as id2, f2.data as data2, " + // child
-                "f4.hash as hash4, f4.fact_id as id4, f4.data as data4, " + // root
-                "f5.hash as hash5, f5.fact_id as id5, f5.data as data5 " +  // source
+                "f3.hash as hash3, f3.fact_id as id3, f3.data as data3, " + // child
+                "f5.hash as hash5, f5.fact_id as id5, f5.data as data5, " + // root
+                "f6.hash as hash6, f6.fact_id as id6, f6.data as data6 " +  // source
             "FROM fact f1 " +       // x: Parent
-            "JOIN edge e1 " +       // child->Parent
-                "ON e1.predecessor_fact_id = f1.fact_id " +
-                "AND e1.role_id = ?3 " +
-            "JOIN fact f2 " +       // child
-                "ON f2.fact_id = e1.successor_fact_id " +
             "JOIN edge e2 " +       // child->Parent
-                "ON e2.successor_fact_id = f2.fact_id " +
+                "ON e2.predecessor_fact_id = f1.fact_id " +
                 "AND e2.role_id = ?4 " +
-            "JOIN fact f3 " +       // Parent
-                "ON f3.fact_id = e2.predecessor_fact_id " +
-            "JOIN edge e3 " +       // Parent->Root
+            "JOIN fact f3 " +       // child
+                "ON f3.fact_id = e2.successor_fact_id " +
+            "JOIN edge e3 " +       // child->Parent
                 "ON e3.successor_fact_id = f3.fact_id " +
                 "AND e3.role_id = ?5 " +
-            "JOIN fact f4 " +       // root
+            "JOIN fact f4 " +       // Parent
                 "ON f4.fact_id = e3.predecessor_fact_id " +
-            "JOIN edge e4 " +       // child->Sources
-                "ON e4.successor_fact_id = f2.fact_id " +
+            "JOIN edge e4 " +       // Parent->Root
+                "ON e4.successor_fact_id = f4.fact_id " +
                 "AND e4.role_id = ?6 " +
-            "JOIN fact f5 " +       // source
+            "JOIN fact f5 " +       // root
                 "ON f5.fact_id = e4.predecessor_fact_id " +
+            "JOIN edge e5 " +       // child->Sources
+                "ON e5.successor_fact_id = f3.fact_id " +
+                "AND e5.role_id = ?7 " +
+            "JOIN fact f6 " +       // source
+                "ON f6.fact_id = e5.predecessor_fact_id " +
             "WHERE f1.fact_type_id = ?1 AND f1.hash = ?2 " +
             "AND NOT EXISTS (" +
-                "SELECT 1 FROM edge e5 " + // Parent->History
-                "JOIN fact f6 " +          // Parent
-                    "ON f6.fact_id = e5.predecessor_fact_id " +
-                "WHERE e5.successor_fact_id = f1.fact_id " +
-                "AND e5.role_id = ?7" +
+                "SELECT 1 FROM edge e1 " + // Parent->History
+                "JOIN fact f2 " +          // Parent
+                    "ON f2.fact_id = e1.successor_fact_id " +
+                "WHERE e1.predecessor_fact_id = f1.fact_id " +
+                "AND e1.role_id = ?3" +
             ") " +
-            "ORDER BY f2.fact_id ASC, f4.fact_id ASC, f5.fact_id ASC"
+            "ORDER BY f3.fact_id ASC, f5.fact_id ASC, f6.fact_id ASC"
         );
 
         var inverse2Sql = inverses[2].InverseSpecification.ToSql();

--- a/Jinaga.Store.SQLite.Test/ExecuteInverseTest.cs
+++ b/Jinaga.Store.SQLite.Test/ExecuteInverseTest.cs
@@ -62,6 +62,64 @@ public class ExecuteInverseTest
             "    ]\n" +
             "} => topic\n"
         );
+
+        var inverse0Sql = inverses[0].InverseSpecification.ToSql();
+        inverse0Sql.SqlQuery.Sql.Should().Be(
+            "SELECT " +
+                "f1.hash as hash1, f1.fact_id as id1, f1.data as data1, " +  // root
+                "f3.hash as hash3, f3.fact_id as id3, f3.data as data3, " +  // projectTopics
+                "f4.hash as hash4, f4.fact_id as id4, f4.data as data4 " +   // topic
+            "FROM fact f1 " +  // root
+            "JOIN edge e1 " +  // project->root
+                "ON e1.successor_fact_id = f1.fact_id " +
+                "AND e1.role_id = ?3 " +
+            "JOIN fact f2 " +  // project
+                "ON f2.fact_id = e1.predecessor_fact_id " +
+            "JOIN edge e2 " +  // projectTopics->project
+                "ON e2.successor_fact_id = f2.fact_id " +
+                "AND e2.role_id = ?4 " +
+            "JOIN fact f3 " +  // projectTopics
+                "ON f3.fact_id = e2.predecessor_fact_id " +
+            "JOIN edge e3 " +  // projectTopics->topic
+                "ON e3.successor_fact_id = f1.fact_id " +
+                "AND e3.role_id = ?5 " +
+            "JOIN fact f4 " +  // topic
+                "ON f4.fact_id = e3.predecessor_fact_id " +
+            "WHERE f1.fact_type_id = ?1 AND f1.hash = ?2 " +
+            "ORDER BY f3.fact_id ASC, f4.fact_id ASC"
+        );
+
+        var inverse1Sql = inverses[1].InverseSpecification.ToSql();
+        inverse1Sql.SqlQuery.Sql.Should().Be(
+            "SELECT " +
+                "f1.hash as hash1, f1.fact_id as id1, f1.data as data1, " +  // next
+                "f2.hash as hash2, f2.fact_id as id2, f2.data as data2, " +  // projectTopics
+                "f4.hash as hash4, f4.fact_id as id4, f4.data as data4, " +  // root
+                "f5.hash as hash5, f5.fact_id as id5, f5.data as data5 " +   // topic
+            "FROM fact f1 " +  // next
+            "JOIN edge e1 " +  // prior->next
+                "ON e1.successor_fact_id = f1.fact_id " +
+                "AND e1.role_id = ?3 " +
+            "JOIN fact f2 " +  // prior
+                "ON f2.fact_id = e1.predecessor_fact_id " +
+            "JOIN edge e2 " +  // projectTopics->prior
+                "ON e2.successor_fact_id = f2.fact_id " +
+                "AND e2.role_id = ?4 " +
+            "JOIN fact f3 " +  // projectTopics
+                "ON f3.fact_id = e2.predecessor_fact_id " +
+            "JOIN edge e3 " +  // project->root
+                "ON e3.successor_fact_id = f3.fact_id " +
+                "AND e3.role_id = ?5 " +
+            "JOIN fact f4 " +  // root
+                "ON f4.fact_id = e3.predecessor_fact_id " +
+            "JOIN edge e4 " +  // projectTopics->topic
+                "ON e4.successor_fact_id = f2.fact_id " +
+                "AND e4.role_id = ?6 " +
+            "JOIN fact f5 " +  // topic
+                "ON f5.fact_id = e4.predecessor_fact_id " +
+            "WHERE f1.fact_type_id = ?1 AND f1.hash = ?2 " +
+            "ORDER BY f2.fact_id ASC, f4.fact_id ASC, f5.fact_id ASC"
+        );
     }
 }
 

--- a/Jinaga.Store.SQLite.Test/ExecuteInverseTest.cs
+++ b/Jinaga.Store.SQLite.Test/ExecuteInverseTest.cs
@@ -134,6 +134,13 @@ public class ExecuteInverseTest
                     "ON f2.fact_id = e1.predecessor_fact_id " +
                 "WHERE e1.successor_fact_id = f1.fact_id " +
                 "AND e1.role_id = ?3" +
+                "AND NOT EXISTS (" +
+                    "SELECT 1 FROM edge e5 " + // Parent->History
+                    "JOIN fact f6 " +          // Parent
+                        "ON f6.fact_id = e5.predecessor_fact_id " +
+                    "WHERE e5.successor_fact_id = f2.fact_id " +
+                    "AND e5.role_id = ?7" +
+                ")" +
             ") " +
             "ORDER BY f4.fact_id ASC, f5.fact_id ASC"
         );

--- a/Jinaga.Store.SQLite.Test/ExecuteInverseTest.cs
+++ b/Jinaga.Store.SQLite.Test/ExecuteInverseTest.cs
@@ -30,6 +30,38 @@ public class ExecuteInverseTest
             "    ]\n" +
             "} => topic\n"
         );
+
+        var inverses = specification.ComputeInverses();
+        inverses.Count.Should().Be(2);
+        inverses[0].InverseSpecification.ToDescriptiveString().Should().Be(
+            "(projectTopics: Test.ProjectTopics [\n" +
+            "    !E {\n" +
+            "        next: Test.ProjectTopics [\n" +
+            "            next->Prior: Test.ProjectTopics = projectTopics\n" +
+            "        ]\n" +
+            "    }\n" +
+            "]) {\n" +
+            "    root: Test.Root [\n" +
+            "        root = projectTopics->Project: Test.Project->Root: Test.Root\n" +
+            "    ]\n" +
+            "    topic: Test.Topic [\n" +
+            "        topic = projectTopics->Topics: Test.Topic\n" +
+            "    ]\n" +
+            "} => topic\n"
+        );
+        inverses[1].InverseSpecification.ToDescriptiveString().Should().Be(
+            "(next: Test.ProjectTopics) {\n" +
+            "    projectTopics: Test.ProjectTopics [\n" +
+            "        projectTopics = next->Prior: Test.ProjectTopics\n" +
+            "    ]\n" +
+            "    root: Test.Root [\n" +
+            "        root = projectTopics->Project: Test.Project->Root: Test.Root\n" +
+            "    ]\n" +
+            "    topic: Test.Topic [\n" +
+            "        topic = projectTopics->Topics: Test.Topic\n" +
+            "    ]\n" +
+            "} => topic\n"
+        );
     }
 }
 

--- a/Jinaga.Store.SQLite.Test/ExecuteInverseTest.cs
+++ b/Jinaga.Store.SQLite.Test/ExecuteInverseTest.cs
@@ -108,29 +108,29 @@ public class ExecuteInverseTest
         var inverse0Sql = inverses[0].InverseSpecification.ToSql();
         inverse0Sql.SqlQuery.Sql.Should().Be(
             "SELECT " +
-                "f1.hash as hash1, f1.fact_id as id1, f1.data as data1, " +
-                "f4.hash as hash4, f4.fact_id as id4, f4.data as data4, " +
-                "f5.hash as hash5, f5.fact_id as id5, f5.data as data5 " +
-            "FROM fact f1 " +
-            "JOIN edge e2 " +
+                "f1.hash as hash1, f1.fact_id as id1, f1.data as data1, " + // child
+                "f4.hash as hash4, f4.fact_id as id4, f4.data as data4, " + // root
+                "f5.hash as hash5, f5.fact_id as id5, f5.data as data5 " +  // source
+            "FROM fact f1 " +       // child
+            "JOIN edge e2 " +       // child->Parent
                 "ON e2.successor_fact_id = f1.fact_id " +
                 "AND e2.role_id = ?4 " +
-            "JOIN fact f3 " +
+            "JOIN fact f3 " +       // Parent
                 "ON f3.fact_id = e2.predecessor_fact_id " +
-            "JOIN edge e3 " +
+            "JOIN edge e3 " +       // Parent->Root
                 "ON e3.successor_fact_id = f3.fact_id " +
                 "AND e3.role_id = ?5 " +
-            "JOIN fact f4 " +
+            "JOIN fact f4 " +       // root
                 "ON f4.fact_id = e3.predecessor_fact_id " +
-            "JOIN edge e4 " +
+            "JOIN edge e4 " +       // child->Sources
                 "ON e4.successor_fact_id = f1.fact_id " +
                 "AND e4.role_id = ?6 " +
-            "JOIN fact f5 " +
+            "JOIN fact f5 " +       // source
                 "ON f5.fact_id = e4.predecessor_fact_id " +
             "WHERE f1.fact_type_id = ?1 AND f1.hash = ?2 " +
             "AND EXISTS (" +
-                "SELECT 1 FROM edge e1 " +
-                "JOIN fact f2 " +
+                "SELECT 1 FROM edge e1 " +  // child->Parent
+                "JOIN fact f2 " +           // Parent
                     "ON f2.fact_id = e1.predecessor_fact_id " +
                 "WHERE e1.successor_fact_id = f1.fact_id " +
                 "AND e1.role_id = ?3" +

--- a/Jinaga.Store.SQLite.Test/ExecuteInverseTest.cs
+++ b/Jinaga.Store.SQLite.Test/ExecuteInverseTest.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+
+namespace Jinaga.Store.SQLite.Test;
+
+public class ExecuteInverseTest
+{
+    [Fact]
+    public void CanGenerateSQLFromInverses()
+    {
+        var specification =
+            Given<Root>.Match((root, facts) =>
+                from projectTopics in facts.OfType<ProjectTopics>()
+                where projectTopics.Project.Root == root && projectTopics.IsCurrent
+                from topic in facts.OfType<Topic>()
+                where projectTopics.Topics.Contains(topic)
+                select topic
+            );
+        specification.ToDescriptiveString().Should().Be(
+            "(root: Test.Root) {\n" +
+            "    projectTopics: Test.ProjectTopics [\n" +
+            "        projectTopics->Project: Test.Project->Root: Test.Root = root\n" +
+            "        !E {\n" +
+            "            next: Test.ProjectTopics [\n" +
+            "                next->Prior: Test.ProjectTopics = projectTopics\n" +
+            "            ]\n" +
+            "        }\n" +
+            "    ]\n" +
+            "    topic: Test.Topic [\n" +
+            "        topic = projectTopics->Topics: Test.Topic\n" +
+            "    ]\n" +
+            "} => topic\n"
+        );
+    }
+}
+
+[FactType("Test.Root")]
+internal record Root(string Name) {}
+
+[FactType("Test.Project")]
+internal record Project(Root Root) {}
+
+[FactType("Test.Topic")]
+internal record Topic(string Name) {}
+
+[FactType("Test.ProjectTopics")]
+internal record ProjectTopics(Project Project, Topic[] Topics, ProjectTopics[] Prior)
+{
+    public Condition IsCurrent => new Condition(facts =>
+        !facts.Any<ProjectTopics>(next => next.Prior.Contains(this)));
+}

--- a/Jinaga.Store.SQLite.Test/ExecuteInverseTest.cs
+++ b/Jinaga.Store.SQLite.Test/ExecuteInverseTest.cs
@@ -203,37 +203,35 @@ public class ExecuteInverseTest
                 "AND e2.role_id = ?4 " +
             "JOIN fact f3 " +       // child
                 "ON f3.fact_id = e2.successor_fact_id " +
-            "JOIN edge e3 " +       // child->Parent->Root
-                "ON e3.successor_fact_id = f3.fact_id " +
-                "AND e3.role_id = ?5 " +
-            "JOIN fact f4 " +       // Parent
-                "ON f4.fact_id = e3.predecessor_fact_id " +
-            "JOIN edge e4 " +       // Parent->Root
-                "ON e4.successor_fact_id = f4.fact_id " +
-                "AND e4.role_id = ?6 " +
-            "JOIN fact f5 " +       // root
-                "ON f5.fact_id = e4.predecessor_fact_id " +
             "JOIN edge e5 " +       // child->Sources
                 "ON e5.successor_fact_id = f3.fact_id " +
                 "AND e5.role_id = ?7 " +
+            "JOIN fact f4 " +       // Parent
+                "ON f4.fact_id = e5.predecessor_fact_id " +
+            "JOIN edge e6 " +       // Parent->Root
+                "ON e6.successor_fact_id = f4.fact_id " +
+                "AND e6.role_id = ?8 " +
+            "JOIN fact f5 " +       // root
+                "ON f5.fact_id = e6.predecessor_fact_id " +
+            "JOIN edge e7 " +       // child->Sources
+                "ON e7.successor_fact_id = f3.fact_id " +
+                "AND e7.role_id = ?9 " +
             "JOIN fact f6 " +       // source
-                "ON f6.fact_id = e5.predecessor_fact_id " +
+                "ON f6.fact_id = e7.predecessor_fact_id " +
             "WHERE f1.fact_type_id = ?1 AND f1.hash = ?2 " +
             "AND EXISTS (" +
-                "SELECT 1 FROM edge e6 " +  // child->Parent
-                "JOIN fact f7 " +           // Parent
-                    "ON f7.fact_id = e6.predecessor_fact_id " +
-                "WHERE e6.successor_fact_id = f3.fact_id " +
-                "AND e6.role_id = ?8" +
+                "SELECT 1 FROM edge e3 " +  // child->Parent
+                "WHERE e3.predecessor_fact_id = f2.fact_id " +
+                "AND e3.successor_fact_id = f3.fact_id " +
+                "AND e3.role_id = ?5 " +
                 "AND NOT EXISTS (" +
-                    "SELECT 1 FROM edge e7 " + // Parent->History
-                    "JOIN fact f8 " +          // Parent
-                        "ON f8.fact_id = e7.predecessor_fact_id " +
-                    "WHERE e7.successor_fact_id = f7.fact_id " +
-                    "AND e7.role_id = ?9" +
+                    "SELECT 1 FROM edge e4 " + // Parent->History
+                    "WHERE e4.predecessor_fact_id = f2.fact_id " +
+                    "AND e4.successor_fact_id = f1.fact_id " +
+                    "AND e4.role_id = ?6" +
                 ")" +
             ") " +
-            "ORDER BY f3.fact_id ASC, f5.fact_id ASC, f6.fact_id ASC"
+            "ORDER BY f2.fact_id ASC, f3.fact_id ASC, f5.fact_id ASC, f6.fact_id ASC"
         );
     }
 }

--- a/Jinaga.Store.SQLite.Test/ExecuteInverseTest.cs
+++ b/Jinaga.Store.SQLite.Test/ExecuteInverseTest.cs
@@ -148,65 +148,92 @@ public class ExecuteInverseTest
         var inverse1Sql = inverses[1].InverseSpecification.ToSql();
         inverse1Sql.SqlQuery.Sql.Should().Be(
             "SELECT " +
-                "f1.hash as hash1, f1.fact_id as id1, f1.data as data1, " +
-                "f2.hash as hash2, f2.fact_id as id2, f2.data as data2, " +
-                "f4.hash as hash4, f4.fact_id as id4, f4.data as data4, " +
-                "f5.hash as hash5, f5.fact_id as id5, f5.data as data5 " +
-            "FROM fact f1 " +
-            "JOIN edge e1 " +
+                "f1.hash as hash1, f1.fact_id as id1, f1.data as data1, " + // x: Parent
+                "f2.hash as hash2, f2.fact_id as id2, f2.data as data2, " + // child
+                "f4.hash as hash4, f4.fact_id as id4, f4.data as data4, " + // root
+                "f5.hash as hash5, f5.fact_id as id5, f5.data as data5 " +  // source
+            "FROM fact f1 " +       // x: Parent
+            "JOIN edge e1 " +       // child->Parent
                 "ON e1.predecessor_fact_id = f1.fact_id " +
                 "AND e1.role_id = ?3 " +
-            "JOIN fact f2 " +
+            "JOIN fact f2 " +       // child
                 "ON f2.fact_id = e1.successor_fact_id " +
-            "JOIN edge e2 " +
+            "JOIN edge e2 " +       // child->Parent
                 "ON e2.successor_fact_id = f2.fact_id " +
                 "AND e2.role_id = ?4 " +
-            "JOIN fact f3 " +
+            "JOIN fact f3 " +       // Parent
                 "ON f3.fact_id = e2.predecessor_fact_id " +
-            "JOIN edge e3 " +
+            "JOIN edge e3 " +       // Parent->Root
                 "ON e3.successor_fact_id = f3.fact_id " +
                 "AND e3.role_id = ?5 " +
-            "JOIN fact f4 " +
+            "JOIN fact f4 " +       // root
                 "ON f4.fact_id = e3.predecessor_fact_id " +
-            "JOIN edge e4 " +
+            "JOIN edge e4 " +       // child->Sources
                 "ON e4.successor_fact_id = f2.fact_id " +
                 "AND e4.role_id = ?6 " +
-            "JOIN fact f5 " +
+            "JOIN fact f5 " +       // source
                 "ON f5.fact_id = e4.predecessor_fact_id " +
             "WHERE f1.fact_type_id = ?1 AND f1.hash = ?2 " +
+            "AND NOT EXISTS (" +
+                "SELECT 1 FROM edge e5 " + // Parent->History
+                "JOIN fact f6 " +          // Parent
+                    "ON f6.fact_id = e5.predecessor_fact_id " +
+                "WHERE e5.successor_fact_id = f1.fact_id " +
+                "AND e5.role_id = ?7" +
+            ") " +
             "ORDER BY f2.fact_id ASC, f4.fact_id ASC, f5.fact_id ASC"
         );
 
         var inverse2Sql = inverses[2].InverseSpecification.ToSql();
         inverse2Sql.SqlQuery.Sql.Should().Be(
             "SELECT " +
-                "f1.hash as hash1, f1.fact_id as id1, f1.data as data1, " +
-                "f2.hash as hash2, f2.fact_id as id2, f2.data as data2, " +
-                "f4.hash as hash4, f4.fact_id as id4, f4.data as data4, " +
-                "f5.hash as hash5, f5.fact_id as id5, f5.data as data5 " +
-            "FROM fact f1 " +
-            "JOIN edge e1 " +
-                "ON e1.predecessor_fact_id = f1.fact_id " +
+                "f1.hash as hash1, f1.fact_id as id1, f1.data as data1, " + // f: Parent
+                "f2.hash as hash2, f2.fact_id as id2, f2.data as data2, " + // x: Parent
+                "f3.hash as hash3, f3.fact_id as id3, f3.data as data3, " + // child
+                "f5.hash as hash5, f5.fact_id as id5, f5.data as data5, " + // root
+                "f6.hash as hash6, f6.fact_id as id6, f6.data as data6 " +  // source
+            "FROM fact f1 " +       // f: Parent
+            "JOIN edge e1 " +       // f->History
+                "ON e1.successor_fact_id = f1.fact_id " +
                 "AND e1.role_id = ?3 " +
-            "JOIN fact f2 " +
-                "ON f2.fact_id = e1.successor_fact_id " +
-            "JOIN edge e2 " +
-                "ON e2.successor_fact_id = f2.fact_id " +
+            "JOIN fact f2 " +       // x: Parent
+                "ON f2.fact_id = e1.predecessor_fact_id " +
+            "JOIN edge e2 " +       // child->Parent
+                "ON e2.predecessor_fact_id = f2.fact_id " +
                 "AND e2.role_id = ?4 " +
-            "JOIN fact f3 " +
-                "ON f3.fact_id = e2.predecessor_fact_id " +
-            "JOIN edge e3 " +
+            "JOIN fact f3 " +       // child
+                "ON f3.fact_id = e2.successor_fact_id " +
+            "JOIN edge e3 " +       // child->Parent->Root
                 "ON e3.successor_fact_id = f3.fact_id " +
                 "AND e3.role_id = ?5 " +
-            "JOIN fact f4 " +
+            "JOIN fact f4 " +       // Parent
                 "ON f4.fact_id = e3.predecessor_fact_id " +
-            "JOIN edge e4 " +
-                "ON e4.successor_fact_id = f2.fact_id " +
+            "JOIN edge e4 " +       // Parent->Root
+                "ON e4.successor_fact_id = f4.fact_id " +
                 "AND e4.role_id = ?6 " +
-            "JOIN fact f5 " +
+            "JOIN fact f5 " +       // root
                 "ON f5.fact_id = e4.predecessor_fact_id " +
+            "JOIN edge e5 " +       // child->Sources
+                "ON e5.successor_fact_id = f3.fact_id " +
+                "AND e5.role_id = ?7 " +
+            "JOIN fact f6 " +       // source
+                "ON f6.fact_id = e5.predecessor_fact_id " +
             "WHERE f1.fact_type_id = ?1 AND f1.hash = ?2 " +
-            "ORDER BY f2.fact_id ASC, f4.fact_id ASC, f5.fact_id ASC"
+            "AND EXISTS (" +
+                "SELECT 1 FROM edge e6 " +  // child->Parent
+                "JOIN fact f7 " +           // Parent
+                    "ON f7.fact_id = e6.predecessor_fact_id " +
+                "WHERE e6.successor_fact_id = f3.fact_id " +
+                "AND e6.role_id = ?8" +
+                "AND NOT EXISTS (" +
+                    "SELECT 1 FROM edge e7 " + // Parent->History
+                    "JOIN fact f8 " +          // Parent
+                        "ON f8.fact_id = e7.predecessor_fact_id " +
+                    "WHERE e7.successor_fact_id = f7.fact_id " +
+                    "AND e7.role_id = ?9" +
+                ")" +
+            ") " +
+            "ORDER BY f3.fact_id ASC, f5.fact_id ASC, f6.fact_id ASC"
         );
     }
 }

--- a/Jinaga.Store.SQLite.Test/ExecuteInverseTest.cs
+++ b/Jinaga.Store.SQLite.Test/ExecuteInverseTest.cs
@@ -190,8 +190,8 @@ public class ExecuteInverseTest
                 "f1.hash as hash1, f1.fact_id as id1, f1.data as data1, " + // f: Parent
                 "f2.hash as hash2, f2.fact_id as id2, f2.data as data2, " + // x: Parent
                 "f3.hash as hash3, f3.fact_id as id3, f3.data as data3, " + // child
-                "f5.hash as hash5, f5.fact_id as id5, f5.data as data5, " + // root
-                "f6.hash as hash6, f6.fact_id as id6, f6.data as data6 " +  // source
+                "f7.hash as hash7, f7.fact_id as id7, f7.data as data7, " + // root
+                "f8.hash as hash8, f8.fact_id as id8, f8.data as data8 " +  // source
             "FROM fact f1 " +       // f: Parent
             "JOIN edge e1 " +       // f->History
                 "ON e1.successor_fact_id = f1.fact_id " +
@@ -203,35 +203,37 @@ public class ExecuteInverseTest
                 "AND e2.role_id = ?4 " +
             "JOIN fact f3 " +       // child
                 "ON f3.fact_id = e2.successor_fact_id " +
-            "JOIN edge e5 " +       // child->Sources
+            "JOIN edge e5 " +       // child->Parent
                 "ON e5.successor_fact_id = f3.fact_id " +
                 "AND e5.role_id = ?7 " +
-            "JOIN fact f4 " +       // Parent
-                "ON f4.fact_id = e5.predecessor_fact_id " +
+            "JOIN fact f6 " +       // Parent
+                "ON f6.fact_id = e5.predecessor_fact_id " +
             "JOIN edge e6 " +       // Parent->Root
-                "ON e6.successor_fact_id = f4.fact_id " +
+                "ON e6.successor_fact_id = f6.fact_id " +
                 "AND e6.role_id = ?8 " +
-            "JOIN fact f5 " +       // root
-                "ON f5.fact_id = e6.predecessor_fact_id " +
+            "JOIN fact f7 " +       // root
+                "ON f7.fact_id = e6.predecessor_fact_id " +
             "JOIN edge e7 " +       // child->Sources
                 "ON e7.successor_fact_id = f3.fact_id " +
                 "AND e7.role_id = ?9 " +
-            "JOIN fact f6 " +       // source
-                "ON f6.fact_id = e7.predecessor_fact_id " +
+            "JOIN fact f8 " +       // source
+                "ON f8.fact_id = e7.predecessor_fact_id " +
             "WHERE f1.fact_type_id = ?1 AND f1.hash = ?2 " +
             "AND EXISTS (" +
                 "SELECT 1 FROM edge e3 " +  // child->Parent
-                "WHERE e3.predecessor_fact_id = f2.fact_id " +
-                "AND e3.successor_fact_id = f3.fact_id " +
+                "JOIN fact f4 " +           // x: Parent
+                    "ON f4.fact_id = e3.predecessor_fact_id " +
+                "WHERE e3.successor_fact_id = f3.fact_id " +
                 "AND e3.role_id = ?5 " +
                 "AND NOT EXISTS (" +
-                    "SELECT 1 FROM edge e4 " + // Parent->History
-                    "WHERE e4.predecessor_fact_id = f2.fact_id " +
-                    "AND e4.successor_fact_id = f1.fact_id " +
+                    "SELECT 1 FROM edge e4 " +  // Parent->History
+                    "JOIN fact f5 " +           // f: Parent
+                        "ON f5.fact_id = e4.successor_fact_id " +
+                    "WHERE e4.predecessor_fact_id = f4.fact_id " +
                     "AND e4.role_id = ?6" +
                 ")" +
             ") " +
-            "ORDER BY f2.fact_id ASC, f3.fact_id ASC, f5.fact_id ASC, f6.fact_id ASC"
+            "ORDER BY f2.fact_id ASC, f3.fact_id ASC, f7.fact_id ASC, f8.fact_id ASC"
         );
     }
 }

--- a/Jinaga.Store.SQLite.Test/Models/Projects.cs
+++ b/Jinaga.Store.SQLite.Test/Models/Projects.cs
@@ -15,5 +15,8 @@ internal record ProjectDeleted(Project project) { }
 [FactType("Project.Restored")]
 internal record ProjectRestored(ProjectDeleted deleted) { }
 
+[FactType("Project.Name")]
+internal record ProjectName(Project project, string value, ProjectName[] prior) { }
+
 [FactType("Assignment")]
 internal record Assignment(Project project, User user, DateTime createdAt) { }

--- a/Jinaga.Store.SQLite.Test/Models/Projects.cs
+++ b/Jinaga.Store.SQLite.Test/Models/Projects.cs
@@ -14,3 +14,6 @@ internal record ProjectDeleted(Project project) { }
 
 [FactType("Project.Restored")]
 internal record ProjectRestored(ProjectDeleted deleted) { }
+
+[FactType("Assignment")]
+internal record Assignment(Project project, User user, DateTime createdAt) { }

--- a/Jinaga.Store.SQLite.Test/QueryGeneratorTests.cs
+++ b/Jinaga.Store.SQLite.Test/QueryGeneratorTests.cs
@@ -343,6 +343,53 @@ public class QueryGeneratorTests
         );
     }
 
+    [Fact]
+    public void ShouldHandleTwoGivensWithExistentialCondition()
+    {
+        var specification = Given<Company, User>.Match((company, user, facts) =>
+            from project in facts.OfType<Project>()
+            where project.department.company == company &&
+                facts.Any<Assignment>(assignment =>
+                    assignment.project == project &&
+                    assignment.user == user)
+            select project
+        );
+        SqlQueryTree sqlQueryTree = SqlFor(specification);
+
+        sqlQueryTree.SqlQuery.Sql.Should().Be(
+            "SELECT " +
+                "f1.hash as hash1, f1.fact_id as id1, f1.data as data1, " +  // company
+                "f5.hash as hash5, f5.fact_id as id5, f5.data as data5, " +  // user
+                "f3.hash as hash3, f3.fact_id as id3, f3.data as data3 " +   // project
+            "FROM fact f1 " +  // company
+            "JOIN edge e1 " +  // department->company
+                "ON e1.predecessor_fact_id = f1.fact_id " +
+                "AND e1.role_id = ?3 " +
+            "JOIN fact f2 " +  // department
+                "ON f2.fact_id = e1.successor_fact_id " +
+            "JOIN edge e2 " +  // project->department
+                "ON e2.predecessor_fact_id = f2.fact_id " +
+                "AND e2.role_id = ?4 " +
+            "JOIN fact f3 " +  // project
+                "ON f3.fact_id = e2.successor_fact_id " +
+            "WHERE f1.fact_type_id = ?1 AND f1.hash = ?2 AND f5.fact_type_id = ?6 AND f5.hash = ?7 " +
+            "AND EXISTS (" +
+                "SELECT 1 " +
+                "FROM edge e3 " +  // assignment->project
+                "JOIN fact f4 " +  // assignment
+                    "ON f4.fact_id = e3.successor_fact_id " +
+                "JOIN edge e4 " +  // assignment->user
+                    "ON e4.successor_fact_id = f4.fact_id " +
+                    "AND e4.role_id = ?8 " +
+                "JOIN fact f5 " +  // user
+                    "ON f5.fact_id = e4.predecessor_fact_id " +
+                "WHERE e3.predecessor_fact_id = f3.fact_id " +
+                "AND e3.role_id = ?5" +
+            ") " +
+            "ORDER BY f3.fact_id ASC"
+        );
+    }
+
     private SqlQueryTree SqlFor(Specification specification)
     {
         var factTypes = GetAllFactTypes(specification);

--- a/Jinaga.Store.SQLite.Test/QueryGeneratorTests.cs
+++ b/Jinaga.Store.SQLite.Test/QueryGeneratorTests.cs
@@ -292,6 +292,46 @@ public class QueryGeneratorTests
     }
 
     [Fact]
+    public void ShouldHandleAdditionalPathConditionsInCondition()
+    {
+        var specification = Given<Project>.Match((project, facts) =>
+            from name in facts.OfType<ProjectName>()
+            where name.project == project &&
+                !facts.Any<ProjectName>(next =>
+                    next.project == project &&
+                    next.prior.Contains(name))
+            select name
+        );
+        SqlQueryTree sqlQueryTree = SqlFor(specification);
+
+        sqlQueryTree.SqlQuery.Sql.Should().Be(
+            "SELECT " +
+                "f1.hash as hash1, f1.fact_id as id1, f1.data as data1, " + // project
+                "f2.hash as hash2, f2.fact_id as id2, f2.data as data2 " +  // name
+            "FROM fact f1 " +   // project
+            "JOIN edge e1 " +   // name->project
+                "ON e1.predecessor_fact_id = f1.fact_id " +
+                "AND e1.role_id = ?3 " +
+            "JOIN fact f2 " +   // name
+                "ON f2.fact_id = e1.successor_fact_id " +
+            "WHERE f1.fact_type_id = ?1 AND f1.hash = ?2 " +
+            "AND NOT EXISTS (" +
+                "SELECT 1 " +
+                "FROM edge e2 " +   // next->project
+                "JOIN fact f3 " +   // next
+                    "ON f3.fact_id = e2.successor_fact_id " +
+                "JOIN edge e3 " +   // next->prior
+                    "ON e3.predecessor_fact_id = f2.fact_id " +
+                    "AND e3.successor_fact_id = f3.fact_id " +
+                    "AND e3.role_id = ?5 " +
+                "WHERE e2.predecessor_fact_id = f1.fact_id " +
+                    "AND e2.role_id = ?4" +
+            ") " +
+            "ORDER BY f2.fact_id ASC"
+        );
+    }
+
+    [Fact]
     public void ShouldHandleTwoGivens()
     {
         var specification = Given<Company, User>.Match((company, user, facts) =>

--- a/Jinaga.Store.SQLite.Test/QueryGeneratorTests.cs
+++ b/Jinaga.Store.SQLite.Test/QueryGeneratorTests.cs
@@ -63,14 +63,14 @@ public class QueryGeneratorTests
     [Fact]
     public void ApplyNegativeExistentialConditions()
     {
-        var specification = Given<Company>.Match((company, facts) =>
-            from project in facts.OfType<Project>()
+        var specification = Given<Company>.Match<Models.Project>((company, facts) =>
+            from project in facts.OfType<Models.Project>()
             where project.department.company == company
             where !(
                 from deleted in facts.OfType<ProjectDeleted>()
                 where deleted.project == project
                 select deleted
-            ).Any()
+            ).Any<ProjectDeleted>()
             select project
         );
         SqlQueryTree sqlQueryTree = SqlFor(specification);
@@ -106,14 +106,14 @@ public class QueryGeneratorTests
     [Fact]
     public void ApplyPositiveExistentialCondition()
     {
-        var specification = Given<Company>.Match((company, facts) =>
-            from project in facts.OfType<Project>()
+        var specification = Given<Company>.Match<Models.Project>((company, facts) =>
+            from project in facts.OfType<Models.Project>()
             where project.department.company == company
             where (
                 from deleted in facts.OfType<ProjectDeleted>()
                 where deleted.project == project
                 select deleted
-            ).Any()
+            ).Any<ProjectDeleted>()
             select project
         );
         SqlQueryTree sqlQueryTree = SqlFor(specification);
@@ -149,8 +149,8 @@ public class QueryGeneratorTests
     [Fact]
     public void ShouldApplyNestedExistentialConditions()
     {
-        var specification = Given<Company>.Match((company, facts) =>
-            from project in facts.OfType<Project>()
+        var specification = Given<Company>.Match<Models.Project>((company, facts) =>
+            from project in facts.OfType<Models.Project>()
             where project.department.company == company
             where !(
                 from deleted in facts.OfType<ProjectDeleted>()
@@ -159,9 +159,9 @@ public class QueryGeneratorTests
                     from restored in facts.OfType<ProjectRestored>()
                     where restored.deleted == deleted
                     select restored
-                ).Any()
+                ).Any<ProjectRestored>()
                 select deleted
-            ).Any()
+            ).Any<ProjectDeleted>()
             select project
         );
         SqlQueryTree sqlQueryTree = SqlFor(specification);
@@ -211,7 +211,7 @@ public class QueryGeneratorTests
             select new
             {
                 department,
-                projects = facts.OfType<Project>(project =>
+                projects = facts.OfType<Models.Project>(project =>
                     project.department == department)
             }
         );
@@ -256,7 +256,7 @@ public class QueryGeneratorTests
     [Fact]
     public void ShouldHandleAdditionalPathConditions()
     {
-        var specification = Given<Project>.Match((project, facts) =>
+        var specification = Given<Models.Project>.Match<ProjectName>((project, facts) =>
             from name in facts.OfType<ProjectName>()
             where name.project == project
             from next in facts.OfType<ProjectName>()
@@ -294,7 +294,7 @@ public class QueryGeneratorTests
     [Fact]
     public void ShouldHandleAdditionalPathConditionsInCondition()
     {
-        var specification = Given<Project>.Match((project, facts) =>
+        var specification = Given<Models.Project>.Match<ProjectName>((project, facts) =>
             from name in facts.OfType<ProjectName>()
             where name.project == project &&
                 !facts.Any<ProjectName>(next =>
@@ -334,7 +334,7 @@ public class QueryGeneratorTests
     [Fact]
     public void ShouldHandleJoinToPredecessorCollection()
     {
-        var specification = Given<Project>.Match((project, facts) =>
+        var specification = Given<Models.Project>.Match<ProjectName>((project, facts) =>
             from name in facts.OfType<ProjectName>()
             where name.project == project
             from prior in facts.OfType<ProjectName>()
@@ -372,8 +372,8 @@ public class QueryGeneratorTests
     [Fact]
     public void ShouldHandleTwoGivens()
     {
-        var specification = Given<Company, User>.Match((company, user, facts) =>
-            from project in facts.OfType<Project>()
+        var specification = Given<Company, User>.Match<Assignment>((company, user, facts) =>
+            from project in facts.OfType<Models.Project>()
             where project.department.company == company
             from assignment in facts.OfType<Assignment>()
             where assignment.project == project
@@ -417,8 +417,8 @@ public class QueryGeneratorTests
     [Fact]
     public void ShouldHandleTwoGivensInOppositeOrder()
     {
-        var specification = Given<Company, User>.Match((company, user, facts) =>
-            from project in facts.OfType<Project>()
+        var specification = Given<Company, User>.Match<Assignment>((company, user, facts) =>
+            from project in facts.OfType<Models.Project>()
             where project.department.company == company
             from assignment in facts.OfType<Assignment>()
             where assignment.user == user
@@ -462,8 +462,8 @@ public class QueryGeneratorTests
     [Fact]
     public void ShouldHandleTwoGivensWithExistentialCondition()
     {
-        var specification = Given<Company, User>.Match((company, user, facts) =>
-            from project in facts.OfType<Project>()
+        var specification = Given<Company, User>.Match<Models.Project>((company, user, facts) =>
+            from project in facts.OfType<Models.Project>()
             where project.department.company == company &&
                 facts.Any<Assignment>(assignment =>
                     assignment.project == project &&

--- a/Jinaga.Store.SQLite.Test/QueryGeneratorTests.cs
+++ b/Jinaga.Store.SQLite.Test/QueryGeneratorTests.cs
@@ -254,6 +254,44 @@ public class QueryGeneratorTests
     }
 
     [Fact]
+    public void ShouldHandleAdditionalPathConditions()
+    {
+        var specification = Given<Project>.Match((project, facts) =>
+            from name in facts.OfType<ProjectName>()
+            where name.project == project
+            from next in facts.OfType<ProjectName>()
+            where next.project == project &&
+                next.prior.Contains(name)
+            select next
+        );
+        SqlQueryTree sqlQueryTree = SqlFor(specification);
+
+        sqlQueryTree.SqlQuery.Sql.Should().Be(
+            "SELECT " +
+                "f1.hash as hash1, f1.fact_id as id1, f1.data as data1, " + // project
+                "f2.hash as hash2, f2.fact_id as id2, f2.data as data2, " + // name
+                "f3.hash as hash3, f3.fact_id as id3, f3.data as data3 " +  // next
+            "FROM fact f1 " +   // project
+            "JOIN edge e1 " +   // name->project
+                "ON e1.predecessor_fact_id = f1.fact_id " +
+                "AND e1.role_id = ?3 " +
+            "JOIN fact f2 " +   // name
+                "ON f2.fact_id = e1.successor_fact_id " +
+            "JOIN edge e2 " +   // next->project
+                "ON e2.predecessor_fact_id = f1.fact_id " +
+                "AND e2.role_id = ?4 " +
+            "JOIN fact f3 " +   // next
+                "ON f3.fact_id = e2.successor_fact_id " +
+            "JOIN edge e3 " +   // next->prior
+                "ON e3.predecessor_fact_id = f2.fact_id " +
+                "AND e3.successor_fact_id = f3.fact_id " +
+                "AND e3.role_id = ?5 " +
+            "WHERE f1.fact_type_id = ?1 AND f1.hash = ?2 " +
+            "ORDER BY f2.fact_id ASC, f3.fact_id ASC"
+        );
+    }
+
+    [Fact]
     public void ShouldHandleTwoGivens()
     {
         var specification = Given<Company, User>.Match((company, user, facts) =>

--- a/Jinaga.Store.SQLite.Test/QueryGeneratorTests.cs
+++ b/Jinaga.Store.SQLite.Test/QueryGeneratorTests.cs
@@ -253,6 +253,51 @@ public class QueryGeneratorTests
         );
     }
 
+    [Fact]
+    public void ShouldHandleTwoGivens()
+    {
+        var specification = Given<Company, User>.Match((company, user, facts) =>
+            from project in facts.OfType<Project>()
+            where project.department.company == company
+            from assignment in facts.OfType<Assignment>()
+            where assignment.project == project
+            where assignment.user == user
+            select assignment
+        );
+        SqlQueryTree sqlQueryTree = SqlFor(specification);
+
+        sqlQueryTree.SqlQuery.Sql.Should().Be(
+            "SELECT " +
+                "f1.hash as hash1, f1.fact_id as id1, f1.data as data1, " +  // company
+                "f5.hash as hash5, f5.fact_id as id5, f5.data as data5, " +  // user
+                "f3.hash as hash3, f3.fact_id as id3, f3.data as data3, " +  // project
+                "f4.hash as hash4, f4.fact_id as id4, f4.data as data4 " +   // assignment
+            "FROM fact f1 " +  // company
+            "JOIN edge e1 " +  // department->company
+                "ON e1.predecessor_fact_id = f1.fact_id " +
+                "AND e1.role_id = ?3 " +
+            "JOIN fact f2 " +  // department
+                "ON f2.fact_id = e1.successor_fact_id " +
+            "JOIN edge e2 " +  // project->department
+                "ON e2.predecessor_fact_id = f2.fact_id " +
+                "AND e2.role_id = ?4 " +
+            "JOIN fact f3 " +  // project
+                "ON f3.fact_id = e2.successor_fact_id " +
+            "JOIN edge e3 " +  // assignment->project
+                "ON e3.predecessor_fact_id = f3.fact_id " +
+                "AND e3.role_id = ?5 " +
+            "JOIN fact f4 " +  // assignment
+                "ON f4.fact_id = e3.successor_fact_id " +
+            "JOIN edge e4 " +  // assignment->user
+                "ON e4.successor_fact_id = f4.fact_id " +
+                "AND e4.role_id = ?8 " +
+            "JOIN fact f5 " +  // user
+                "ON f5.fact_id = e4.predecessor_fact_id " +
+            "WHERE f1.fact_type_id = ?1 AND f1.hash = ?2 AND f5.fact_type_id = ?6 AND f5.hash = ?7 " +
+            "ORDER BY f3.fact_id ASC, f4.fact_id ASC"
+        );
+    }
+
     private SqlQueryTree SqlFor(Specification specification)
     {
         var factTypes = GetAllFactTypes(specification);

--- a/Jinaga.Store.SQLite.Test/SpecificationExtensions.cs
+++ b/Jinaga.Store.SQLite.Test/SpecificationExtensions.cs
@@ -1,0 +1,191 @@
+using Jinaga.Facts;
+using Jinaga.Projections;
+using Jinaga.Store.SQLite.Builder;
+using Jinaga.Store.SQLite.Generation;
+using System.Collections.Immutable;
+
+namespace Jinaga.Store.SQLite.Test;
+
+internal static class SpecificationExtensions
+{
+    public static SqlQueryTree ToSql(this Specification specification)
+    {
+        var factTypes = GetAllFactTypes(specification);
+        var roleMap = GetAllRoles(specification, factTypes);
+
+        var givenTuple = specification.Givens
+            .Select((given, index) => (
+                name: given.Label.Name,
+                reference: new FactReference(given.Label.Type, $"{index + 1001}")
+            ))
+            .Aggregate(FactReferenceTuple.Empty, (tuple, item) => tuple.Add(item.name, item.reference));
+
+        var descriptionBuilder = new ResultDescriptionBuilder(factTypes, roleMap);
+        string str = specification.ToString();
+        var description = descriptionBuilder.Build(givenTuple, specification);
+
+        var sqlQueryTree = SqlGenerator.CreateSqlQueryTree(description);
+        return sqlQueryTree;
+    }
+
+    private static ImmutableDictionary<string, int> GetAllFactTypes(Specification specification)
+    {
+        return GetAllFactTypesFromSpecification(specification)
+            .Select((name, index) => KeyValuePair.Create(name, index + 1))
+            .ToImmutableDictionary();
+    }
+
+    private static IEnumerable<string> GetAllFactTypesFromSpecification(Specification specification)
+    {
+        var factTypeNames = specification.Givens
+            .Select(g => g.Label.Type)
+            .ToImmutableList();
+        factTypeNames = factTypeNames.AddRange(GetAllFactTypesFromMatches(specification.Matches));
+        if (specification.Projection is CompoundProjection compoundProjection)
+        {
+            factTypeNames = factTypeNames.AddRange(GetAllFactTypesFromProjection(compoundProjection));
+        }
+        return factTypeNames.Distinct();
+    }
+
+    private static IEnumerable<string> GetAllFactTypesFromMatches(ImmutableList<Match> matches)
+    {
+        var factTypeNames = ImmutableList<string>.Empty;
+        foreach (var match in matches)
+        {
+            factTypeNames = factTypeNames.Add(match.Unknown.Type);
+            foreach (var pathCondition in match.PathConditions)
+            {
+                factTypeNames = factTypeNames.AddRange(
+                    pathCondition.RolesLeft.Select(role =>
+                        role.TargetType));
+                factTypeNames = factTypeNames.AddRange(
+                    pathCondition.RolesRight.Select(role =>
+                        role.TargetType));
+            }
+            foreach (var existentialCondition in match.ExistentialConditions)
+            {
+                factTypeNames = factTypeNames.AddRange(
+                    GetAllFactTypesFromMatches(existentialCondition.Matches));
+            }
+        }
+        return factTypeNames.Distinct();
+    }
+
+    private static IEnumerable<string> GetAllFactTypesFromProjection(CompoundProjection compoundProjection)
+    {
+        var factTypeNames = ImmutableList<string>.Empty;
+
+        foreach (var name in compoundProjection.Names)
+        {
+            var projection = compoundProjection.GetProjection(name);
+            if (projection is CompoundProjection nestedCompoundProjection)
+            {
+                factTypeNames = factTypeNames.AddRange(
+                    GetAllFactTypesFromProjection(nestedCompoundProjection));
+            }
+            else if (projection is CollectionProjection collectionProjection)
+            {
+                factTypeNames = factTypeNames.AddRange(
+                    GetAllFactTypesFromMatches(collectionProjection.Matches));
+                if (collectionProjection.Projection is CompoundProjection nestedCompoundProjection2)
+                {
+                    factTypeNames = factTypeNames.AddRange(
+                        GetAllFactTypesFromProjection(nestedCompoundProjection2));
+                }
+            }
+        }
+        return factTypeNames.Distinct();
+    }
+
+    private static ImmutableDictionary<int, ImmutableDictionary<string, int>> GetAllRoles(Specification specification, ImmutableDictionary<string, int> factTypes)
+    {
+        var distinctRoles = GetAllRolesFromSpecification(specification)
+            .GroupBy(pair => pair.factType, pair => pair.roleName)
+            .SelectMany(group => group.Distinct().Select(roleName => new
+            {
+                FactType = group.Key,
+                RoleName = roleName
+            }));
+        var rolesByFactTypeId = distinctRoles
+            .Select((pair, index) => new
+            {
+                FactTypeId = factTypes[pair.FactType],
+                RoleName = pair.RoleName,
+                RoleId = index + 1
+            })
+            .GroupBy(role => role.FactTypeId, role => KeyValuePair.Create(
+                role.RoleName, role.RoleId
+            ))
+            .Select(pair => KeyValuePair.Create(pair.Key, pair.ToImmutableDictionary()))
+            .ToImmutableDictionary();
+        return rolesByFactTypeId;
+    }
+
+    private static IEnumerable<(string factType, string roleName)> GetAllRolesFromSpecification(Specification specification)
+    {
+        var typesByLabel = specification.Givens
+            .Select(g => KeyValuePair.Create(g.Label.Name, g.Label.Type))
+            .ToImmutableDictionary();
+        typesByLabel = typesByLabel.AddRange(specification.Matches
+            .Select(match => KeyValuePair.Create(match.Unknown.Name, match.Unknown.Type)));
+        var roles = GetAllRolesFromMatches(typesByLabel, specification.Matches).ToImmutableList();
+        roles = roles.AddRange(GetAllRolesFromProjection(typesByLabel, specification.Projection));
+        return roles;
+    }
+
+    private static IEnumerable<(string factType, string roleName)> GetAllRolesFromMatches(ImmutableDictionary<string, string> typesByLabel, ImmutableList<Match> matches)
+    {
+        var roles = ImmutableList<(string factType, string roleName)>.Empty;
+        foreach (var match in matches)
+        {
+            foreach (var pathCondition in match.PathConditions)
+            {
+                var type = match.Unknown.Type;
+                foreach (var role in pathCondition.RolesLeft)
+                {
+                    roles = roles.Add((type, role.Name));
+                    type = role.TargetType;
+                }
+                type = typesByLabel[pathCondition.LabelRight];
+                foreach (var role in pathCondition.RolesRight)
+                {
+                    roles = roles.Add((type, role.Name));
+                    type = role.TargetType;
+                }
+            }
+            foreach (var existentialCondition in match.ExistentialConditions)
+            {
+                typesByLabel = typesByLabel.AddRange(existentialCondition.Matches
+                    .Select(match => KeyValuePair.Create(match.Unknown.Name, match.Unknown.Type)));
+                roles = roles.AddRange(GetAllRolesFromMatches(typesByLabel, existentialCondition.Matches));
+            }
+        }
+        return roles;
+    }
+
+    private static IEnumerable<(string factType, string roleName)> GetAllRolesFromProjection(ImmutableDictionary<string, string> typesByLabel, Projection projection)
+    {
+        var roles = ImmutableList<(string factType, string roleName)>.Empty;
+        if (projection is CompoundProjection compoundProjection)
+        {
+            foreach (var name in compoundProjection.Names)
+            {
+                var nestedProjection = compoundProjection.GetProjection(name);
+                if (nestedProjection is CompoundProjection nestedCompoundProjection)
+                {
+                    roles = roles.AddRange(GetAllRolesFromProjection(typesByLabel, nestedCompoundProjection));
+                }
+                else if (nestedProjection is CollectionProjection collectionProjection)
+                {
+                    roles = roles.AddRange(GetAllRolesFromMatches(typesByLabel, collectionProjection.Matches));
+                    if (collectionProjection.Projection is CompoundProjection nestedCompoundProjection2)
+                    {
+                        roles = roles.AddRange(GetAllRolesFromProjection(typesByLabel, nestedCompoundProjection2));
+                    }
+                }
+            }
+        }
+        return roles;
+    }
+}

--- a/Jinaga.Store.SQLite.Test/SpecificationExtensions.cs
+++ b/Jinaga.Store.SQLite.Test/SpecificationExtensions.cs
@@ -130,6 +130,12 @@ internal static class SpecificationExtensions
         typesByLabel = typesByLabel.AddRange(specification.Matches
             .Select(match => KeyValuePair.Create(match.Unknown.Name, match.Unknown.Type)));
         var roles = GetAllRolesFromMatches(typesByLabel, specification.Matches).ToImmutableList();
+        foreach (var existentialCondition in specification.Givens.SelectMany(g => g.ExistentialConditions))
+        {
+            typesByLabel = typesByLabel.AddRange(existentialCondition.Matches
+                .Select(match => KeyValuePair.Create(match.Unknown.Name, match.Unknown.Type)));
+            roles = roles.AddRange(GetAllRolesFromMatches(typesByLabel, existentialCondition.Matches));
+        }
         roles = roles.AddRange(GetAllRolesFromProjection(typesByLabel, specification.Projection));
         return roles;
     }

--- a/Jinaga.Store.SQLite/Builder/ResultDescriptionBuilder.cs
+++ b/Jinaga.Store.SQLite/Builder/ResultDescriptionBuilder.cs
@@ -97,7 +97,13 @@ namespace Jinaga.Store.SQLite.Builder
                     // The path describes which not-exists condition we are currently building on.
                     // Because the path is not empty, labeled facts will be included in the output.
                     var contextWithCondition = context.WithExistentialCondition(existentialCondition.Exists);
-                    var contextConditional = AddEdges(contextWithCondition, givens, givenTuple, existentialCondition.Matches);
+
+                    // Remove all labels that share a name with an unknown in the existential
+                    // condition so that they can be redefined within its scope.
+                    var nestedContext = existentialCondition.Matches.Select(match => match.Unknown)
+                        .Aggregate(contextWithCondition, (context, label) => context.WithoutLabel(label));
+
+                    var contextConditional = AddEdges(nestedContext, givens, givenTuple, existentialCondition.Matches);
 
                     // If the negative existential condition is not satisfiable, then
                     // that means that the condition will always be true.

--- a/Jinaga.Store.SQLite/Builder/ResultDescriptionBuilderContext.cs
+++ b/Jinaga.Store.SQLite/Builder/ResultDescriptionBuilderContext.cs
@@ -164,5 +164,15 @@ namespace Jinaga.Store.SQLite.Builder
             }
             return this;
         }
+
+        public ResultDescriptionBuilderContext WithoutLabel(Label unknown)
+        {
+            if (KnownFacts.ContainsKey(unknown.Name))
+            {
+                var factByLabel = KnownFacts.Remove(unknown.Name);
+                return new ResultDescriptionBuilderContext(QueryDescription, factByLabel, Path);
+            }
+            return this;
+        }
     }
 }

--- a/Jinaga.Store.SQLite/Builder/ResultDescriptionBuilderContext.cs
+++ b/Jinaga.Store.SQLite/Builder/ResultDescriptionBuilderContext.cs
@@ -71,16 +71,9 @@ namespace Jinaga.Store.SQLite.Builder
             var facts = QueryDescription.Facts.Add(factDescription);
             var input = new InputDescription(label.Name, label.Type, factIndex, factTypeParameter, factHashParameter);
             var parameters = QueryDescription.Parameters.Add(factTypeId).Add(hash);
-            if (Path.Count == 0)
-            {
-                var inputs = QueryDescription.Inputs.Add(input);
-                var queryDescription = QueryDescription.WithInputs(inputs).WithParameters(parameters).WithFacts(facts);
-                return new ResultDescriptionBuilderContext(queryDescription, KnownFacts.Add(label.Name, factDescription), Path);
-            }
-            else
-            {
-                throw new NotImplementedException();
-            }
+            var inputs = QueryDescription.Inputs.Add(input);
+            var queryDescription = QueryDescription.WithInputs(inputs).WithParameters(parameters).WithFacts(facts);
+            return new ResultDescriptionBuilderContext(queryDescription, KnownFacts.Add(label.Name, factDescription), Path);
         }
 
         public (ResultDescriptionBuilderContext context, int factIndex) WithFact(string type)

--- a/Jinaga.Store.SQLite/Generation/SqlGenerator.cs
+++ b/Jinaga.Store.SQLite/Generation/SqlGenerator.cs
@@ -66,7 +66,11 @@ namespace Jinaga.Store.SQLite.Generation
             {
                 if (writtenFactIndexes.Contains(firstEdge.SuccessorFactIndex))
                 {
-                    throw new NotImplementedException();
+                    whereClause = whereClause.Add(
+                        $"e{firstEdge.EdgeIndex}.predecessor_fact_id = f{firstEdge.PredecessorFactIndex}.fact_id" +
+                        $" AND e{firstEdge.EdgeIndex}.successor_fact_id = f{firstEdge.SuccessorFactIndex}.fact_id" +
+                        $" AND e{firstEdge.EdgeIndex}.role_id = ?{firstEdge.RoleParameter}"
+                    );
                 }
                 else
                 {

--- a/Jinaga/Specifications/LinqProcessor.cs
+++ b/Jinaga/Specifications/LinqProcessor.cs
@@ -119,15 +119,20 @@ namespace Jinaga.Specifications
                     .Where(label => !existentialCondition.Matches
                         .Any(match => match.Unknown.Name == label));
 
-                // There should be only one.
-                if (unsatisfiedLabels.Count() != 1)
-                {
-                    throw new ArgumentException("The existential condition does not apply to exactly one unknown");
-                }
-                var unsatisfiedLabel = unsatisfiedLabels.Single();
+                // Those unsatisfied labels should be the unknowns of the matches.
+                // Find the last match that has one of those labels.
+                var unsatisfiedMatch = matches
+                    .Where(match => unsatisfiedLabels
+                        .Any(label => match.Unknown.Name == label))
+                    .LastOrDefault();
 
-                int matchIndex = matches.FindIndex(match => match.Unknown.Name == unsatisfiedLabel);
-                var match = matches[matchIndex];
+                if (unsatisfiedMatch == null)
+                {
+                    throw new ArgumentException("The existential condition does not apply to any unknown");
+                }
+
+                int matchIndex = matches.IndexOf(unsatisfiedMatch);
+                var match = unsatisfiedMatch;
                 var conditions = match.ExistentialConditions;
                 var newCondition = new ExistentialCondition(existentialCondition.Exists, existentialCondition.Matches);
                 conditions = conditions.Add(newCondition);


### PR DESCRIPTION
The SQL generator is receiving a specification containing an unexpected path condition inside of an existential condition. Both the predecessor and successor facts of the path have already been written.

While attempting to reproduce the issue, I discovered a few more bugs. This PR includes those fixes.

The exception occurred while generating SQL for an inverse. Perhaps the condition cannot be expressed with the LINQ converter, but only happens with inverses. Maybe the inverse algorithm has a defect.

The search continues.