### PR TITLE
Fix inverses containing existential conditions that reference multiple unknowns

### DIFF
--- a/Jinaga.Test/Model/University.cs
+++ b/Jinaga.Test/Model/University.cs
@@ -1,0 +1,62 @@
+using Jinaga.Extensions;
+using System.Linq;
+
+namespace Jinaga.Test.Model.University;
+
+[FactType("University.Student")]
+public record Student(string publicKey);
+
+[FactType("University.Organization")]
+public record Organization(string identifier);
+
+[FactType("University.Application")]
+public record Application(Student student, Organization organization, DateTime appliedAt);
+
+[FactType("University.Enrollment")]
+public record Enrollment(Application application);
+
+[FactType("University.Rejection")]
+public record Rejection(Application application);
+
+[FactType("University.Course")]
+public record Course(Organization organization, string code, string name);
+
+[FactType("University.Semester")]
+public record Semester(Organization organization, int year, string term);
+
+[FactType("University.Instructor")]
+public record Instructor(Organization organization, string name);
+
+[FactType("University.Offering")]
+public record Offering(Course course, Semester semester, Instructor instructor, string days, string time)
+{
+    public Relation<OfferingLocation> Locations => Relation.Define<OfferingLocation>(() =>
+        from location in this.Successors().OfType<OfferingLocation>(location => location.offering)
+        where location.Successors().No<OfferingLocation>(next => next.prior)
+        select location
+    );
+}
+
+[FactType("University.Offering.Location")]
+public record OfferingLocation(Offering offering, string building, string room, OfferingLocation[] prior);
+
+[FactType("University.Offering.Delete")]
+public record OfferingDelete(Offering offering, DateTime deletedAt);
+
+[FactType("University.Registration")]
+public record Registration(Enrollment enrollment, Offering offering);
+
+[FactType("University.Drop")]
+public record Drop(Registration registration);
+
+[FactType("University.Fail")]
+public record Fail(Registration registration, int grade);
+
+[FactType("University.Complete")]
+public record Complete(Registration registration, int grade);
+
+[FactType("SearchIndex.Record")]
+public record SearchIndexRecord(Offering offering, Guid recordId);
+
+[FactType("SearchIndex.Record.LocationUpdate")]
+public record SearchIndexRecordLocationUpdate(SearchIndexRecord record, OfferingLocation location);

--- a/Jinaga.Test/Specifications/MultiJoinTest.cs
+++ b/Jinaga.Test/Specifications/MultiJoinTest.cs
@@ -21,12 +21,8 @@ public class MultiJoinTest
     [Fact]
     public void CanInvertSpecificationWithMultipleJoins()
     {
-        // When a specification includes an existential condition, that condition becomes
-        // a condition of a given in the inverse. If the existential condition references
-        // just one variable, then that is the inverse that it is associated with. If, however,
-        // the existential condition references multiple variables, then it is associated
-        // with each of those variables. Within the existential condition, the unknowns must
-        // include the other variables that are referenced.
+        // Existential conditions move to their inverses. They attach to the lowest
+        // unknown that the condition references.
         var recordsToUpdate = Given<Semester>.Match(semester =>
             from offering in semester.Successors().OfType<Offering>(offering => offering.semester)
             from record in offering.Successors().OfType<SearchIndexRecord>(record => record.offering)
@@ -76,12 +72,6 @@ public class MultiJoinTest
                         next->prior: University.Offering.Location = location
                     ]
                 }
-                !E {
-                    update: SearchIndex.Record.LocationUpdate [
-                        update->record: SearchIndex.Record = record
-                        update->location: University.Offering.Location = location
-                    ]
-                }
             ]) {
                 offering: University.Offering [
                     offering = location->offering: University.Offering
@@ -91,6 +81,12 @@ public class MultiJoinTest
                 ]
                 record: SearchIndex.Record [
                     record->offering: University.Offering = offering
+                    !E {
+                        update: SearchIndex.Record.LocationUpdate [
+                            update->record: SearchIndex.Record = record
+                            update->location: University.Offering.Location = location
+                        ]
+                    }
                 ]
             } => {
                 location = location
@@ -102,12 +98,6 @@ public class MultiJoinTest
             (next: University.Offering.Location) {
                 location: University.Offering.Location [
                     location = next->prior: University.Offering.Location
-                    !E {
-                        update: SearchIndex.Record.LocationUpdate [
-                            update->record: SearchIndex.Record = record
-                            update->location: University.Offering.Location = location
-                        ]
-                    }
                 ]
                 offering: University.Offering [
                     offering = location->offering: University.Offering
@@ -117,6 +107,12 @@ public class MultiJoinTest
                 ]
                 record: SearchIndex.Record [
                     record->offering: University.Offering = offering
+                    !E {
+                        update: SearchIndex.Record.LocationUpdate [
+                            update->record: SearchIndex.Record = record
+                            update->location: University.Offering.Location = location
+                        ]
+                    }
                 ]
             } => {
                 location = location
@@ -304,14 +300,6 @@ public class MultiJoinTest
                     next->prior: University.Offering.Location = location
                 ]
             }
-            !E {
-                update: SearchIndex.Record.LocationUpdate [
-                    update->location: University.Offering.Location = location
-                ]
-                record: SearchIndex.Record [
-                    record = update->record: SearchIndex.Record
-                ]
-            }
         ]) {
             offering: University.Offering [
                 offering = location->offering: University.Offering
@@ -321,6 +309,12 @@ public class MultiJoinTest
             ]
             record: SearchIndex.Record [
                 record->offering: University.Offering = offering
+                !E {
+                    update: SearchIndex.Record.LocationUpdate [
+                        update->location: University.Offering.Location = location
+                        update->record: SearchIndex.Record = record
+                    ]
+                }
             ]
         } => {
             location = location

--- a/Jinaga.Test/Specifications/MultiJoinTest.cs
+++ b/Jinaga.Test/Specifications/MultiJoinTest.cs
@@ -1,0 +1,132 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using Jinaga.Extensions;
+using Jinaga.Test.Model.University;
+
+namespace Jinaga.Test.Specifications;
+
+public class MultiJoinTest
+{
+    class SearchRecord
+    {
+        public string CourseCode { get; init; }
+        public string CourseName { get; init; }
+        public string Days { get; init; }
+        public string Time { get; init; }
+        public string Instructor { get; init; }
+        public string Location { get; set; }
+    }
+
+    [Fact]
+    public async Task CanRunInverseSpecificationWithMultipleJoins()
+    {
+        var j = JinagaTest.Create();
+
+        var university = await j.Fact(new Organization("6003"));
+        var student = await j.Fact(new Student("---PUBLIC KEY---"));
+        var application = await j.Fact(new Application(student, university, DateTime.Parse("2022-02-04")));
+        var enrollment = await j.Fact(new Enrollment(application));
+
+        List<Course> courses = [
+            await j.Fact(new Course(university, "CS 101", "Introduction to Computer Science")),
+            await j.Fact(new Course(university, "CS 201", "Data Structures and Algorithms")),
+            await j.Fact(new Course(university, "CS 301", "Software Engineering")),
+            await j.Fact(new Course(university, "CS 401", "Artificial Intelligence")),
+            await j.Fact(new Course(university, "CS 501", "Machine Learning")),
+            await j.Fact(new Course(university, "CS 601", "Quantum Computing"))
+        ];
+
+        List<Instructor> instructors = [
+            await j.Fact(new Instructor(university, "Dr. Smith")),
+            await j.Fact(new Instructor(university, "Dr. Jones")),
+            await j.Fact(new Instructor(university, "Dr. Lee")),
+            await j.Fact(new Instructor(university, "Dr. Kim")),
+            await j.Fact(new Instructor(university, "Dr. Patel")),
+            await j.Fact(new Instructor(university, "Dr. Singh"))
+        ];
+
+        List<Semester> semesters = [
+            await j.Fact(new Semester(university, 2022, "Spring")),
+            await j.Fact(new Semester(university, 2022, "Summer")),
+            await j.Fact(new Semester(university, 2022, "Fall")),
+            await j.Fact(new Semester(university, 2023, "Spring")),
+            await j.Fact(new Semester(university, 2023, "Summer")),
+            await j.Fact(new Semester(university, 2023, "Fall"))
+        ];
+        var currentSemester = semesters[1];
+
+        var random = new Random(29693);
+
+        List<Offering> offerings = new List<Offering>();
+        string[] possibleDays = new string[] { "MF", "TTr", "MW", "WF" };
+        string[] possibleBuildings = new string[] { "Building A", "Building B", "Building C", "Building D" };
+        string[] possibleRooms = new string[] { "101", "102", "103", "104" };
+        for (int i = 0; i < 100; i++)
+        {
+            var course = courses[random.Next(courses.Count)];
+            var semester = semesters[random.Next(semesters.Count)];
+            var instructor = instructors[random.Next(instructors.Count)];
+            var days = possibleDays[random.Next(possibleDays.Length)];
+            var time = (8 + random.Next(12)).ToString() + ":00";
+            var building = possibleBuildings[random.Next(possibleBuildings.Length)];
+            var room = possibleRooms[random.Next(possibleRooms.Length)];
+            var offering = await j.Fact(new Offering(course, semester, instructor, days, time));
+            var location = await j.Fact(new OfferingLocation(offering, building, room, new OfferingLocation[0]));
+            offerings.Add(offering);
+        }
+
+        // Watch for offerings to index.
+        Dictionary<Guid, SearchRecord> index = new Dictionary<Guid, SearchRecord>();
+
+        var offeringsToIndex = Given<Semester>.Match(semester =>
+            from offering in semester.Successors().OfType<Offering>(offering => offering.semester)
+            where offering.Successors().No<OfferingDelete>(deleted => deleted.offering)
+            where offering.Successors().No<SearchIndexRecord>(record => record.offering)
+            select offering);
+        var indexInsertSubscription = j.Subscribe(offeringsToIndex, currentSemester, async offering =>
+        {
+            // Create a record for the offering
+            var recordId = Guid.NewGuid();
+            index[recordId] = new SearchRecord
+            {
+                CourseCode = offering.course.code,
+                CourseName = offering.course.name,
+                Days = offering.days,
+                Time = offering.time,
+                Instructor = offering.instructor.name,
+                Location = "TBA"
+            };
+            await j.Fact(new SearchIndexRecord(offering, recordId));
+        });
+
+        // Watch for index records to update.
+        var recordsToUpdate = Given<Semester>.Match(semester =>
+            from offering in semester.Successors().OfType<Offering>(offering => offering.semester)
+            from record in offering.Successors().OfType<SearchIndexRecord>(record => record.offering)
+            from location in offering.Locations
+            where !(
+                from update in record.Successors().OfType<SearchIndexRecordLocationUpdate>(update => update.record)
+                where update.location == location
+                select update
+            ).Any()
+            select new { record, location }
+        );
+        var indexUpdateSubscription = j.Subscribe(recordsToUpdate, currentSemester, async work =>
+        {
+            var record = work.record;
+            var location = work.location;
+            index[record.recordId].Location = location.building + " " + location.room;
+            await j.Fact(new SearchIndexRecordLocationUpdate(record, location));
+        });
+
+        // Trigger an index update.
+        var offeringAndLocationInSemester = Given<Semester>.Match(semester =>
+            from offering in semester.Successors().OfType<Offering>(offering => offering.semester)
+            from location in offering.Locations
+            select new { offering, location }
+        );
+        var offeringsAndLocations = await j.Query(offeringAndLocationInSemester, currentSemester);
+        await j.Fact(new OfferingLocation(offeringsAndLocations[0].offering, "Building E", "105", [offeringsAndLocations[0].location]));
+    }
+}

--- a/Jinaga.Test/Specifications/MultiJoinTest.cs
+++ b/Jinaga.Test/Specifications/MultiJoinTest.cs
@@ -38,34 +38,6 @@ public class MultiJoinTest
             inverse.InverseSpecification.ToString().ReplaceLineEndings()).ToArray();
         inverses.Should().BeEquivalentTo([
             """
-            (record: SearchIndex.Record) {
-                offering: University.Offering [
-                    offering = record->offering: University.Offering
-                ]
-                semester: University.Semester [
-                    semester = offering->semester: University.Semester
-                ]
-                location: University.Offering.Location [
-                    location->offering: University.Offering = offering
-                    !E {
-                        next: University.Offering.Location [
-                            next->prior: University.Offering.Location = location
-                        ]
-                    }
-                    !E {
-                        update: SearchIndex.Record.LocationUpdate [
-                            update->record: SearchIndex.Record = record
-                            update->location: University.Offering.Location = location
-                        ]
-                    }
-                ]
-            } => {
-                location = location
-                record = record
-            }
-
-            """,
-            """
             (location: University.Offering.Location [
                 !E {
                     next: University.Offering.Location [
@@ -76,9 +48,6 @@ public class MultiJoinTest
                 offering: University.Offering [
                     offering = location->offering: University.Offering
                 ]
-                semester: University.Semester [
-                    semester = offering->semester: University.Semester
-                ]
                 record: SearchIndex.Record [
                     record->offering: University.Offering = offering
                     !E {
@@ -87,6 +56,9 @@ public class MultiJoinTest
                             update->location: University.Offering.Location = location
                         ]
                     }
+                ]
+                semester: University.Semester [
+                    semester = offering->semester: University.Semester
                 ]
             } => {
                 location = location
@@ -121,24 +93,52 @@ public class MultiJoinTest
 
             """,
             """
-            (update: SearchIndex.Record.LocationUpdate) {
+            (record: SearchIndex.Record) {
+                offering: University.Offering [
+                    offering = record->offering: University.Offering
+                ]
+                semester: University.Semester [
+                    semester = offering->semester: University.Semester
+                ]
                 location: University.Offering.Location [
+                    location->offering: University.Offering = offering
+                    !E {
+                        next: University.Offering.Location [
+                            next->prior: University.Offering.Location = location
+                        ]
+                    }
+                    !E {
+                        update: SearchIndex.Record.LocationUpdate [
+                            update->record: SearchIndex.Record = record
+                            update->location: University.Offering.Location = location
+                        ]
+                    }
+                ]
+            } => {
+                location = location
+                record = record
+            }
+
+            """,
+            """
+            (update: SearchIndex.Record.LocationUpdate) {
+                record: SearchIndex.Record [
+                    record = update->record: SearchIndex.Record
+                ]
+                offering: University.Offering [
+                    offering = record->offering: University.Offering
+                ]
+                semester: University.Semester [
+                    semester = offering->semester: University.Semester
+                ]
+                location: University.Offering.Location [
+                    location->offering: University.Offering = offering
                     location = update->location: University.Offering.Location
                     !E {
                         next: University.Offering.Location [
                             next->prior: University.Offering.Location = location
                         ]
                     }
-                ]
-                offering: University.Offering [
-                    offering = location->offering: University.Offering
-                ]
-                semester: University.Semester [
-                    semester = offering->semester: University.Semester
-                ]
-                record: SearchIndex.Record [
-                    record = update->record: SearchIndex.Record
-                    record->offering: University.Offering = offering
                 ]
             } => {
                 location = location

--- a/Jinaga/Pipelines/Inverter.cs
+++ b/Jinaga/Pipelines/Inverter.cs
@@ -114,11 +114,7 @@ namespace Jinaga.Pipelines
                     .AddRange(existentialCondition.Matches);
                 foreach (var match in existentialCondition.Matches)
                 {
-                    string preShake = string.Join("\n", matches.Select(m => m.ToString()));
-                    Console.WriteLine(preShake);
                     matches = ShakeTree(matches, match.Unknown.Name);
-                    string postShake = string.Join("\n", matches.Select(m => m.ToString()));
-                    Console.WriteLine(postShake);
 
                     var inverseSpecification = new Specification(
                         ImmutableList.Create(

--- a/Jinaga/Pipelines/SpecificationEdge.cs
+++ b/Jinaga/Pipelines/SpecificationEdge.cs
@@ -1,0 +1,60 @@
+using System;
+using Jinaga.Projections;
+
+namespace Jinaga.Pipelines
+{
+    internal class SpecificationEdge
+    {
+        private string labelLeft;
+        private PathCondition pathCondition;
+
+        public SpecificationEdge(string name, PathCondition pathCondition)
+        {
+            this.labelLeft = name;
+            this.pathCondition = pathCondition;
+        }
+
+        public bool ConnectsWith(string label)
+        {
+            return labelLeft == label || pathCondition.LabelRight == label;
+        }
+
+        public PathCondition WithLeft(string label)
+        {
+            if (labelLeft == label)
+            {
+                // The path is already in the correct order.
+                return pathCondition;
+            }
+            else if (pathCondition.LabelRight == label)
+            {
+                // Swap the left and right labels.
+                return new PathCondition(
+                    pathCondition.RolesRight,
+                    labelLeft,
+                    pathCondition.RolesLeft
+                );
+            }
+            else
+            {
+                throw new InvalidOperationException($"Cannot connect edge with label {label}");
+            }
+        }
+
+        public string OtherLabel(string label)
+        {
+            if (labelLeft == label)
+            {
+                return pathCondition.LabelRight;
+            }
+            else if (pathCondition.LabelRight == label)
+            {
+                return labelLeft;
+            }
+            else
+            {
+                throw new InvalidOperationException($"Cannot find other label for edge with label {label}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Addressed an error related to tuple references and improved the handling of inverses in multi-join tests. Reimplemented ShakeTree using graph traversal for better performance and clarity.