### PR TITLE
Enhance queue processing with tests and optimizations

### DIFF
--- a/Jinaga.Store.SQLite.Test/ExportFactsTest.cs
+++ b/Jinaga.Store.SQLite.Test/ExportFactsTest.cs
@@ -151,11 +151,13 @@ namespace Jinaga.Store.SQLite.Test
                     Environment.SpecialFolder.LocalApplicationData),
                     "ExportFactsTest.db"),
                 new NullLoggerFactory());
+            var options = new JinagaClientOptions();
             var jinagaClient = new JinagaClient(
                 store,
                 new LocalNetwork(),
                 [],
-                new NullLoggerFactory());
+                new NullLoggerFactory(),
+                options);
             return jinagaClient;
         }
     }

--- a/Jinaga.Store.SQLite.Test/Migrations/Migration202412Test.cs
+++ b/Jinaga.Store.SQLite.Test/Migrations/Migration202412Test.cs
@@ -176,11 +176,13 @@ public class Migration202412Test
         var store = new SQLiteStore(
             sqlitePath,
             new NullLoggerFactory());
+        var options = new JinagaClientOptions();
         var jinagaClient = new JinagaClient(
             store,
             network,
             [],
-            new NullLoggerFactory());
+            new NullLoggerFactory(),
+            options);
         return jinagaClient;
     }
 }

--- a/Jinaga.Store.SQLite.Test/NullTest.cs
+++ b/Jinaga.Store.SQLite.Test/NullTest.cs
@@ -51,6 +51,7 @@ public class NullTest
 
     private static JinagaClient GivenJinagaClient(IStore? store = null)
     {
-        return new JinagaClient(store ?? new SQLiteStore(SQLitePath, NullLoggerFactory.Instance), new LocalNetwork(), [], NullLoggerFactory.Instance);
+        var options = new JinagaClientOptions();
+        return new JinagaClient(store ?? new SQLiteStore(SQLitePath, NullLoggerFactory.Instance), new LocalNetwork(), [], NullLoggerFactory.Instance, options);
     }
 }

--- a/Jinaga.Store.SQLite.Test/Observers/WatchFromNetworkTest.cs
+++ b/Jinaga.Store.SQLite.Test/Observers/WatchFromNetworkTest.cs
@@ -144,7 +144,8 @@ public class WatchFromNetworkTest
 
     private static JinagaClient GivenJinagaClient(FakeNetwork network)
     {
-        return new JinagaClient(new SQLiteStore(SQLitePath, NullLoggerFactory.Instance), network, [], NullLoggerFactory.Instance);
+        var options = new JinagaClientOptions();
+        return new JinagaClient(new SQLiteStore(SQLitePath, NullLoggerFactory.Instance), network, [], NullLoggerFactory.Instance, options);
     }
 
     private class OfficeViewModel

--- a/Jinaga.Store.SQLite.Test/Purge/PurgeOnDemandTest.cs
+++ b/Jinaga.Store.SQLite.Test/Purge/PurgeOnDemandTest.cs
@@ -23,7 +23,8 @@ public class PurgeOnDemandTest
         PurgeConditions purgeConditions = PurgeConditions.Empty
             .Purge<Project>().WhenExists<ProjectDeleted>(deleted => deleted.project);
         store = new SQLiteStore(SQLitePath, NullLoggerFactory.Instance);
-        j = new JinagaClient(store, new LocalNetwork(), purgeConditions.Validate(), NullLoggerFactory.Instance);
+        var options = new JinagaClientOptions();
+        j = new JinagaClient(store, new LocalNetwork(), purgeConditions.Validate(), NullLoggerFactory.Instance, options);
     }
 
     [Fact]

--- a/Jinaga.Store.SQLite.Test/Purge/RealTimePurgeSkipLevelTest.cs
+++ b/Jinaga.Store.SQLite.Test/Purge/RealTimePurgeSkipLevelTest.cs
@@ -23,7 +23,8 @@ public class RealTimePurgeSkipLevelTest
         PurgeConditions purgeConditions = PurgeConditions.Empty
             .Purge<Order>().WhenExists<OrderCancelledReason>(ocr => ocr.orderCancelled.order);
         store = new SQLiteStore(SQLitePath, NullLoggerFactory.Instance);
-        j = new JinagaClient(store, new LocalNetwork(), purgeConditions.Validate(), NullLoggerFactory.Instance);
+        var options = new JinagaClientOptions();
+        j = new JinagaClient(store, new LocalNetwork(), purgeConditions.Validate(), NullLoggerFactory.Instance, options);
     }
 
     [Fact]

--- a/Jinaga.Store.SQLite.Test/Purge/RealTimePurgeTest.cs
+++ b/Jinaga.Store.SQLite.Test/Purge/RealTimePurgeTest.cs
@@ -23,7 +23,8 @@ public class RealTimePurgeTest
         PurgeConditions purgeConditions = PurgeConditions.Empty
             .Purge<Order>().WhenExists<OrderCancelled>(oc => oc.order);
         store = new SQLiteStore(SQLitePath, NullLoggerFactory.Instance);
-        j = new JinagaClient(store, new LocalNetwork(), purgeConditions.Validate(), NullLoggerFactory.Instance);
+        var options = new JinagaClientOptions();
+        j = new JinagaClient(store, new LocalNetwork(), purgeConditions.Validate(), NullLoggerFactory.Instance, options);
     }
 
     [Fact]

--- a/Jinaga.Store.SQLite.Test/QueryTest.cs
+++ b/Jinaga.Store.SQLite.Test/QueryTest.cs
@@ -20,7 +20,8 @@ public class QueryTest
         if (File.Exists(SQLitePath))
             File.Delete(SQLitePath);
 
-        j = new JinagaClient(new SQLiteStore(SQLitePath, NullLoggerFactory.Instance), new LocalNetwork(), [], NullLoggerFactory.Instance);
+        var options = new JinagaClientOptions();
+        j = new JinagaClient(new SQLiteStore(SQLitePath, NullLoggerFactory.Instance), new LocalNetwork(), [], NullLoggerFactory.Instance, options);
         this.output = output;
     }
 

--- a/Jinaga.Store.SQLite.Test/StoreTest.cs
+++ b/Jinaga.Store.SQLite.Test/StoreTest.cs
@@ -876,7 +876,7 @@ public class StoreTest
         var store = new MemoryStore();
         var loggerFactory = NullLoggerFactory.Instance;
         var networkManager = new NetworkManager(new LocalNetwork(), store, loggerFactory, (FactGraph g, ImmutableList<Fact> l, CancellationToken c) => Task.CompletedTask);
-        var factManager = new FactManager(store, networkManager, [], loggerFactory);
+        var factManager = new FactManager(store, networkManager, [], loggerFactory, 0);
         var graph = factManager.Serialize(fact);
         var lastRef = graph.Last;
         return lastRef;
@@ -884,7 +884,8 @@ public class StoreTest
 
     private static JinagaClient GivenJinagaClient(IStore? store = null, INetwork? network = null)
     {
-        return new JinagaClient(store ?? new SQLiteStore(SQLitePath, NullLoggerFactory.Instance), network ?? new LocalNetwork(), [], NullLoggerFactory.Instance);
+        var options = new JinagaClientOptions();
+        return new JinagaClient(store ?? new SQLiteStore(SQLitePath, NullLoggerFactory.Instance), network ?? new LocalNetwork(), [], NullLoggerFactory.Instance, options);
     }
 
     private static SQLiteStore GivenSQLiteStore()

--- a/Jinaga.Store.SQLite.Test/Users/SingleUsePrincipalTest.cs
+++ b/Jinaga.Store.SQLite.Test/Users/SingleUsePrincipalTest.cs
@@ -57,7 +57,8 @@ public class SingleUsePrincipalTest
 
     private static JinagaClient GivenJinagaClient(IStore? store = null, INetwork? network = null)
     {
-        return new JinagaClient(store ?? new SQLiteStore(SQLitePath, NullLoggerFactory.Instance), network ?? new LocalNetwork(), [], NullLoggerFactory.Instance);
+        var options = new JinagaClientOptions();
+        return new JinagaClient(store ?? new SQLiteStore(SQLitePath, NullLoggerFactory.Instance), network ?? new LocalNetwork(), [], NullLoggerFactory.Instance, options);
     }
 
     private static LocalNetwork GivenLocalNetwork()

--- a/Jinaga.Store.SQLite/JinagaSQLiteClient.cs
+++ b/Jinaga.Store.SQLite/JinagaSQLiteClient.cs
@@ -1,4 +1,4 @@
-﻿using Jinaga.DefaultImplementations;
+﻿﻿using Jinaga.DefaultImplementations;
 using Jinaga.Http;
 using Jinaga.Projections;
 using Jinaga.Services;
@@ -45,7 +45,7 @@ namespace Jinaga.Store.SQLite
                 ? (INetwork)new LocalNetwork()
                 : new HttpNetwork(options.HttpEndpoint, options.HttpAuthenticationProvider, loggerFactory, options.RetryConfiguration);
             var purgeConditions = CreatePurgeConditions(options);
-            return new JinagaClient(store, network, purgeConditions, loggerFactory);
+            return new JinagaClient(store, network, purgeConditions, loggerFactory, options);
         }
 
         private static ImmutableList<Specification> CreatePurgeConditions(JinagaClientOptions options)

--- a/Jinaga.Store.SQLite/JinagaSQLiteClient.cs
+++ b/Jinaga.Store.SQLite/JinagaSQLiteClient.cs
@@ -1,4 +1,4 @@
-﻿﻿using Jinaga.DefaultImplementations;
+﻿using Jinaga.DefaultImplementations;
 using Jinaga.Http;
 using Jinaga.Projections;
 using Jinaga.Services;

--- a/Jinaga.Test/BlogTests.cs
+++ b/Jinaga.Test/BlogTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using Jinaga.Extensions;
 

--- a/Jinaga.Test/Facts/DeserializeTest.cs
+++ b/Jinaga.Test/Facts/DeserializeTest.cs
@@ -2,7 +2,6 @@
 using Jinaga.Serialization;
 using Jinaga.Test.Model;
 using Jinaga.Test.Model.Order;
-using System;
 using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 

--- a/Jinaga.Test/Facts/HashTest.cs
+++ b/Jinaga.Test/Facts/HashTest.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using Jinaga.Facts;
 using Jinaga.Serialization;

--- a/Jinaga.Test/Facts/LocalFactTest.cs
+++ b/Jinaga.Test/Facts/LocalFactTest.cs
@@ -54,6 +54,7 @@ public class LocalFactTest
 
     private static JinagaClient GivenJinagaClient(FakeNetwork network)
     {
-        return new JinagaClient(new MemoryStore(), network, [], NullLoggerFactory.Instance);
+        var options = new JinagaClientOptions();
+        return new JinagaClient(new MemoryStore(), network, [], NullLoggerFactory.Instance, options);
     }
 }

--- a/Jinaga.Test/Facts/NullableFieldsTest.cs
+++ b/Jinaga.Test/Facts/NullableFieldsTest.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Globalization;
 
 namespace Jinaga.Test.Facts;

--- a/Jinaga.Test/Facts/OptimizationTest.cs
+++ b/Jinaga.Test/Facts/OptimizationTest.cs
@@ -2,7 +2,6 @@ using Jinaga.Facts;
 using Jinaga.Products;
 using Jinaga.Serialization;
 using Jinaga.Test.Model;
-using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.CompilerServices;

--- a/Jinaga.Test/Facts/SerializeTest.cs
+++ b/Jinaga.Test/Facts/SerializeTest.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Jinaga.Facts;

--- a/Jinaga.Test/Facts/StoreTest.cs
+++ b/Jinaga.Test/Facts/StoreTest.cs
@@ -1,6 +1,5 @@
 ﻿using Jinaga;
 using Jinaga.Test.Model;
-using System;
 
 namespace Jinaga.Test.Facts
 {

--- a/Jinaga.Test/Facts/VersioningTest.cs
+++ b/Jinaga.Test/Facts/VersioningTest.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Runtime.CompilerServices;
 using Jinaga.Facts;
 using Jinaga.Serialization;

--- a/Jinaga.Test/Fakes/CountingFakeNetwork.cs
+++ b/Jinaga.Test/Fakes/CountingFakeNetwork.cs
@@ -1,0 +1,64 @@
+﻿using Jinaga.Facts;
+using Jinaga.Projections;
+using Jinaga.Services;
+using System.Collections.Immutable;
+using System.Threading;
+using Xunit.Abstractions;
+
+namespace Jinaga.Test.Fakes
+{
+    internal class CountingFakeNetwork : INetwork
+    {
+        private readonly FakeNetwork innerNetwork;
+        public int SaveCallCount { get; private set; } = 0;
+        public FactGraph UploadedGraph => innerNetwork.UploadedGraph;
+        public ImmutableList<Fact> UploadedFacts => innerNetwork.UploadedFacts;
+
+        public event INetwork.AuthenticationStateChanged OnAuthenticationStateChanged
+        {
+            add { innerNetwork.OnAuthenticationStateChanged += value; }
+            remove { innerNetwork.OnAuthenticationStateChanged -= value; }
+        }
+
+        public CountingFakeNetwork(ITestOutputHelper output)
+        {
+            innerNetwork = new FakeNetwork(output);
+        }
+
+        public void AddFeed(string name, object[] facts, int delay = 0)
+        {
+            innerNetwork.AddFeed(name, facts, delay);
+        }
+
+        public Task<ImmutableList<string>> Feeds(FactReferenceTuple givenTuple, Specification specification, CancellationToken cancellationToken)
+        {
+            return innerNetwork.Feeds(givenTuple, specification, cancellationToken);
+        }
+
+        public Task<(ImmutableList<FactReference> references, string bookmark)> FetchFeed(string feed, string bookmark, CancellationToken cancellationToken)
+        {
+            return innerNetwork.FetchFeed(feed, bookmark, cancellationToken);
+        }
+
+        public Task<FactGraph> Load(ImmutableList<FactReference> factReferences, CancellationToken cancellationToken)
+        {
+            return innerNetwork.Load(factReferences, cancellationToken);
+        }
+
+        public Task<(FactGraph graph, UserProfile profile)> Login(CancellationToken cancellationToken)
+        {
+            return innerNetwork.Login(cancellationToken);
+        }
+
+        public Task Save(FactGraph graph, CancellationToken cancellationToken)
+        {
+            SaveCallCount++;
+            return innerNetwork.Save(graph, cancellationToken);
+        }
+
+        public void StreamFeed(string feed, string bookmark, CancellationToken cancellationToken, Func<ImmutableList<FactReference>, string, Task> onResponse, Action<Exception> onError)
+        {
+            innerNetwork.StreamFeed(feed, bookmark, cancellationToken, onResponse, onError);
+        }
+    }
+}

--- a/Jinaga.Test/Fakes/FakeNetwork.cs
+++ b/Jinaga.Test/Fakes/FakeNetwork.cs
@@ -2,7 +2,6 @@
 using Jinaga.Projections;
 using Jinaga.Serialization;
 using Jinaga.Services;
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;

--- a/Jinaga.Test/Fakes/PersistentMemoryStore.cs
+++ b/Jinaga.Test/Fakes/PersistentMemoryStore.cs
@@ -1,0 +1,10 @@
+using Jinaga.Services;
+using Jinaga.Storage;
+
+namespace Jinaga.Test.Fakes
+{
+    public class PersistentMemoryStore : MemoryStore, IStore
+    {
+        public new bool IsPersistent => true;
+    }
+}

--- a/Jinaga.Test/Fakes/TestFact.cs
+++ b/Jinaga.Test/Fakes/TestFact.cs
@@ -1,0 +1,5 @@
+namespace Jinaga.Test.Fakes
+{
+    [FactType("Test.Fact")]
+    public record TestFact(string identifier);
+}

--- a/Jinaga.Test/Model/Blog.cs
+++ b/Jinaga.Test/Model/Blog.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Jinaga.Test.Model;
+﻿namespace Jinaga.Test.Model;
 
 [FactType("Blog.Site")]
 public record Site(User creator, string identifier) { }

--- a/Jinaga.Test/Model/Corporate.cs
+++ b/Jinaga.Test/Model/Corporate.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using Jinaga.Extensions;
 using Jinaga.Patterns;
 

--- a/Jinaga.Test/Model/DWS.cs
+++ b/Jinaga.Test/Model/DWS.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 
 namespace Jinaga.Test.Model.DWS

--- a/Jinaga.Test/Model/School.cs
+++ b/Jinaga.Test/Model/School.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Jinaga.Test.Model;
+﻿namespace Jinaga.Test.Model;
 
 [FactType("School")]
 public record OldSchool(string name, Guid? identifier) {}

--- a/Jinaga.Test/Model/Skylane.cs
+++ b/Jinaga.Test/Model/Skylane.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 
 namespace Jinaga.Test.Model

--- a/Jinaga.Test/NestedWatchTest.cs
+++ b/Jinaga.Test/NestedWatchTest.cs
@@ -1,4 +1,3 @@
-using System;
 using Jinaga.Observers;
 using Jinaga.Test.Fakes;
 using Jinaga.Test.Model;

--- a/Jinaga.Test/Observers/LocalWatchTest.cs
+++ b/Jinaga.Test/Observers/LocalWatchTest.cs
@@ -232,7 +232,8 @@ public class LocalWatchTest
 
     private static JinagaClient GivenJinagaClient(FakeNetwork network)
     {
-        return new JinagaClient(new MemoryStore(), network, [], NullLoggerFactory.Instance);
+        var options = new JinagaClientOptions();
+        return new JinagaClient(new MemoryStore(), network, [], NullLoggerFactory.Instance, options);
     }
 
     private void WhenAddCourses(FakeNetwork network, School school)

--- a/Jinaga.Test/Observers/SubscribeFromNetworkTest.cs
+++ b/Jinaga.Test/Observers/SubscribeFromNetworkTest.cs
@@ -138,7 +138,8 @@ public class SubscribeFromNetworkTest
 
     private static JinagaClient GivenJinagaClient(FakeNetwork network)
     {
-        return new JinagaClient(new MemoryStore(), network, [], NullLoggerFactory.Instance);
+        var options = new JinagaClientOptions();
+        return new JinagaClient(new MemoryStore(), network, [], NullLoggerFactory.Instance, options);
     }
 
     private class OfficeViewModel

--- a/Jinaga.Test/Observers/WatchFromNetworkTest.cs
+++ b/Jinaga.Test/Observers/WatchFromNetworkTest.cs
@@ -139,7 +139,8 @@ public class WatchFromNetworkTest
 
     private static JinagaClient GivenJinagaClient(FakeNetwork network)
     {
-        return new JinagaClient(new MemoryStore(), network, [], NullLoggerFactory.Instance);
+        var options = new JinagaClientOptions();
+        return new JinagaClient(new MemoryStore(), network, [], NullLoggerFactory.Instance, options);
     }
 
     private class OfficeViewModel

--- a/Jinaga.Test/Pipelines/ProjectionTest.cs
+++ b/Jinaga.Test/Pipelines/ProjectionTest.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using System;
 using Jinaga.Test.Model;
 
 namespace Jinaga.Test.Pipelines

--- a/Jinaga.Test/QueryLocalTest.cs
+++ b/Jinaga.Test/QueryLocalTest.cs
@@ -54,7 +54,8 @@ namespace Jinaga.Test
 
         public QueryLocalTest()
         {
-            j = new JinagaClient(new MemoryStore(), new NeverUsedNetwork(), [], NullLoggerFactory.Instance);
+            var options = new JinagaClientOptions();
+            j = new JinagaClient(new MemoryStore(), new NeverUsedNetwork(), [], NullLoggerFactory.Instance, options);
         }
 
         [Fact]

--- a/Jinaga.Test/QueryLocalTest.cs
+++ b/Jinaga.Test/QueryLocalTest.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using System.Threading;
 using Jinaga.Facts;

--- a/Jinaga.Test/QueryTest.cs
+++ b/Jinaga.Test/QueryTest.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using Jinaga.Extensions;
 using Jinaga.Test.Model;

--- a/Jinaga.Test/QueueProcessorTest.cs
+++ b/Jinaga.Test/QueueProcessorTest.cs
@@ -23,7 +23,7 @@ namespace Jinaga.Test
             // Arrange
             var network = new CountingFakeNetwork(output);
             var options = new JinagaClientOptions { QueueProcessingDelay = 50 };
-            var j = new JinagaClient(new MemoryStore(), network, ImmutableList<Specification>.Empty, NullLoggerFactory.Instance, options);
+            var j = new JinagaClient(new PersistentMemoryStore(), network, ImmutableList<Specification>.Empty, NullLoggerFactory.Instance, options);
             
             // Act
             await j.Fact(new TestFact("fact1"));
@@ -103,7 +103,7 @@ namespace Jinaga.Test
             // Arrange
             var network = new CountingFakeNetwork(output);
             var options = new JinagaClientOptions { QueueProcessingDelay = 50 };
-            var j = new JinagaClient(new MemoryStore(), network, ImmutableList<Specification>.Empty, NullLoggerFactory.Instance, options);
+            var j = new JinagaClient(new PersistentMemoryStore(), network, ImmutableList<Specification>.Empty, NullLoggerFactory.Instance, options);
             
             // Act - Create a blog site with content
             var user = await j.Fact(new User("test-user"));

--- a/Jinaga.Test/QueueProcessorTest.cs
+++ b/Jinaga.Test/QueueProcessorTest.cs
@@ -1,0 +1,121 @@
+using Jinaga.Projections;
+using Jinaga.Storage;
+using Jinaga.Test.Fakes;
+using Jinaga.Test.Model;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Collections.Immutable;
+using Xunit.Abstractions;
+
+namespace Jinaga.Test
+{
+    public class QueueProcessorTest
+    {
+        private readonly ITestOutputHelper output;
+
+        public QueueProcessorTest(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+        [Fact]
+        public async Task MultipleFacts_SavedInQuickSuccession_UsesSingleNetworkOperation()
+        {
+            // Arrange
+            var network = new CountingFakeNetwork(output);
+            var options = new JinagaClientOptions { QueueProcessingDelay = 50 };
+            var j = new JinagaClient(new MemoryStore(), network, ImmutableList<Specification>.Empty, NullLoggerFactory.Instance, options);
+            
+            // Act
+            await j.Fact(new TestFact("fact1"));
+            await j.Fact(new TestFact("fact2"));
+            await j.Fact(new TestFact("fact3"));
+            
+            await Task.Delay(100); // Wait for debounce period
+            
+            // Assert
+            network.SaveCallCount.Should().Be(1);
+            network.UploadedFacts.Count.Should().Be(3);
+        }
+
+        [Fact]
+        public async Task FactsSavedWithLongerDelays_UseMultipleNetworkOperations()
+        {
+            // Arrange
+            var network = new CountingFakeNetwork(output);
+            var options = new JinagaClientOptions { QueueProcessingDelay = 50 };
+            var j = new JinagaClient(new MemoryStore(), network, ImmutableList<Specification>.Empty, NullLoggerFactory.Instance, options);
+            
+            // Act
+            await j.Fact(new TestFact("fact1"));
+            await Task.Delay(100); // Wait longer than debounce period
+            
+            await j.Fact(new TestFact("fact2"));
+            await Task.Delay(100); // Wait longer than debounce period
+            
+            await j.Fact(new TestFact("fact3"));
+            await Task.Delay(100); // Wait longer than debounce period
+            
+            // Assert
+            network.SaveCallCount.Should().Be(3);
+            network.UploadedFacts.Count.Should().Be(3);
+        }
+
+        [Fact]
+        public async Task QueueProcessingDelayZero_DisablesDebouncing()
+        {
+            // Arrange
+            var network = new CountingFakeNetwork(output);
+            var options = new JinagaClientOptions { QueueProcessingDelay = 0 };
+            var j = new JinagaClient(new MemoryStore(), network, ImmutableList<Specification>.Empty, NullLoggerFactory.Instance, options);
+            
+            // Act
+            await j.Fact(new TestFact("fact1"));
+            await j.Fact(new TestFact("fact2"));
+            await j.Fact(new TestFact("fact3"));
+            
+            await Task.Delay(50); // Short delay to ensure processing completes
+            
+            // Assert
+            network.SaveCallCount.Should().Be(3); // Each fact should trigger a separate save
+            network.UploadedFacts.Count.Should().Be(3);
+        }
+
+        [Fact]
+        public async Task Push_ProcessesQueueImmediately()
+        {
+            // Arrange
+            var network = new CountingFakeNetwork(output);
+            var options = new JinagaClientOptions { QueueProcessingDelay = 1000 }; // Long delay
+            var j = new JinagaClient(new MemoryStore(), network, ImmutableList<Specification>.Empty, NullLoggerFactory.Instance, options);
+            
+            // Act
+            await j.Fact(new TestFact("fact1"));
+            await j.Push(); // Should process immediately without waiting
+            
+            // Assert
+            network.SaveCallCount.Should().Be(1);
+            network.UploadedFacts.Count.Should().Be(1);
+        }
+
+        [Fact]
+        public async Task CreatingRelatedFacts_UsesSingleNetworkOperation()
+        {
+            // Arrange
+            var network = new CountingFakeNetwork(output);
+            var options = new JinagaClientOptions { QueueProcessingDelay = 50 };
+            var j = new JinagaClient(new MemoryStore(), network, ImmutableList<Specification>.Empty, NullLoggerFactory.Instance, options);
+            
+            // Act - Create a blog site with content
+            var user = await j.Fact(new User("test-user"));
+            var site = await j.Fact(new Jinaga.Test.Model.Site(user, "example.com"));
+            var content = await j.Fact(new Content(site, "/blog/post1"));
+            var publish = await j.Fact(new Publish(content, DateTime.UtcNow));
+            
+            await Task.Delay(100); // Wait for debounce period
+            
+            // Assert
+            network.SaveCallCount.Should().Be(1); // All facts should be saved in one operation
+            network.UploadedFacts.Count.Should().Be(4);
+        }
+    }
+}

--- a/Jinaga.Test/Specifications/LinqProcessorTest.cs
+++ b/Jinaga.Test/Specifications/LinqProcessorTest.cs
@@ -3,7 +3,6 @@ using Jinaga.Pipelines;
 using Jinaga.Projections;
 using Jinaga.Specifications;
 using Jinaga.Visualizers;
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;

--- a/Jinaga.Test/Specifications/MultiJoinTest.cs
+++ b/Jinaga.Test/Specifications/MultiJoinTest.cs
@@ -272,6 +272,8 @@ public class MultiJoinTest
         var offeringsAndLocations = await j.Query(offeringAndLocationInSemester, currentSemester);
         await j.Fact(new OfferingLocation(offeringsAndLocations[0].offering, "Building E", "105", [offeringsAndLocations[0].location]));
 
+        await j.Unload();
+
         // Verify that the index was updated.
         // The location "Building E 105" is expected to be in the updated state exactly once.
         indexRecordUpdatedEvent.Wait(5000);

--- a/Jinaga.Test/Specifications/MultiProjectionTest.cs
+++ b/Jinaga.Test/Specifications/MultiProjectionTest.cs
@@ -1,6 +1,5 @@
 using Jinaga.Observers;
 using Jinaga.Test.Model.DWS;
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;

--- a/Jinaga.Test/Specifications/ProjectionTest.cs
+++ b/Jinaga.Test/Specifications/ProjectionTest.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using Jinaga.Observers;
 using Jinaga.Test.Model;

--- a/Jinaga.Test/Specifications/ProjectionVersioningTest.cs
+++ b/Jinaga.Test/Specifications/ProjectionVersioningTest.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 
 namespace Jinaga.Test.Specifications;

--- a/Jinaga.Test/Specifications/SpecificationTest.cs
+++ b/Jinaga.Test/Specifications/SpecificationTest.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using Jinaga.Extensions;
 using Jinaga.Patterns;

--- a/Jinaga.Test/TestingExtensions.cs
+++ b/Jinaga.Test/TestingExtensions.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Jinaga.Test
 {
     static class TestingExtensions

--- a/Jinaga.Test/Users/SingleUsePrincipalTest.cs
+++ b/Jinaga.Test/Users/SingleUsePrincipalTest.cs
@@ -54,7 +54,8 @@ public class SingleUsePrincipalTest
 
     private JinagaClient GivenJinagaClient(FakeNetwork fakeNetwork)
     {
-        return new JinagaClient(new MemoryStore(), fakeNetwork, [], NullLoggerFactory.Instance);
+        var options = new JinagaClientOptions();
+        return new JinagaClient(new MemoryStore(), fakeNetwork, [], NullLoggerFactory.Instance, options);
     }
 }
 

--- a/Jinaga.Test/WatchTest.cs
+++ b/Jinaga.Test/WatchTest.cs
@@ -1,6 +1,5 @@
 ﻿using Jinaga.Test.Fakes;
 using Jinaga.Test.Model;
-using System;
 using System.Linq;
 
 namespace Jinaga.Test

--- a/Jinaga.UnitTest/JinagaTest.cs
+++ b/Jinaga.UnitTest/JinagaTest.cs
@@ -20,12 +20,13 @@ namespace Jinaga.UnitTest
 
         public static JinagaClient Create(Action<JinagaTestOptions> configure)
         {
-            var options = new JinagaTestOptions();
-            configure(options);
+            var testOptions = new JinagaTestOptions();
+            configure(testOptions);
             var loggerFactory = NullLoggerFactory.Instance;
             var network = new SimulatedNetwork(
-                options.User == null ? null : options.User.publicKey);
-            var client = new JinagaClient(new MemoryStore(), network, ImmutableList<Specification>.Empty, loggerFactory);
+                testOptions.User == null ? null : testOptions.User.publicKey);
+            var clientOptions = new JinagaClientOptions();
+            var client = new JinagaClient(new MemoryStore(), network, ImmutableList<Specification>.Empty, loggerFactory, clientOptions);
             return client;
         }
     }

--- a/Jinaga/JinagaInternal.cs
+++ b/Jinaga/JinagaInternal.cs
@@ -7,7 +7,6 @@ using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.IO;
-using Jinaga.Http;
 
 namespace Jinaga
 {

--- a/Jinaga/Managers/FactManager.cs
+++ b/Jinaga/Managers/FactManager.cs
@@ -255,6 +255,7 @@ namespace Jinaga.Managers
         public async Task Unload()
         {
             VerifyNotUnloaded();
+            await queueProcessor.ProcessQueueNow(default).ConfigureAwait(false);
             unloaded = true;
             var freezePendingTasks = pendingTasks;
             if (freezePendingTasks.Count > 0)

--- a/Jinaga/Managers/QueueProcessor.cs
+++ b/Jinaga/Managers/QueueProcessor.cs
@@ -1,0 +1,146 @@
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jinaga.Managers
+{
+    /// <summary>
+    /// Processes the outgoing queue with debouncing to improve performance when saving multiple facts in quick succession.
+    /// </summary>
+    class QueueProcessor
+    {
+        private readonly NetworkManager networkManager;
+        private readonly ILogger logger;
+        private readonly int delayMilliseconds;
+        
+        private Timer? debounceTimer;
+        private readonly object timerLock = new object();
+        private bool isProcessing = false;
+        private TaskCompletionSource<bool>? currentProcessingTask;
+
+        /// <summary>
+        /// Creates a new queue processor.
+        /// </summary>
+        /// <param name="networkManager">The network manager to use for sending facts.</param>
+        /// <param name="loggerFactory">A factory configured for logging.</param>
+        /// <param name="delayMilliseconds">The delay in milliseconds before processing the queue.</param>
+        public QueueProcessor(NetworkManager networkManager, ILoggerFactory loggerFactory, int delayMilliseconds)
+        {
+            this.networkManager = networkManager;
+            this.logger = loggerFactory.CreateLogger<QueueProcessor>();
+            this.delayMilliseconds = delayMilliseconds;
+        }
+
+        /// <summary>
+        /// Schedules the queue for processing after the configured delay.
+        /// If called multiple times within the delay period, only one processing operation will occur.
+        /// </summary>
+        /// <returns>A task that completes when the queue has been processed.</returns>
+        public Task ScheduleProcessing()
+        {
+            lock (timerLock)
+            {
+                // If immediate processing is configured, process right away
+                if (delayMilliseconds <= 0)
+                {
+                    return ProcessQueueImmediately();
+                }
+
+                // If we're already processing, return the current task
+                if (isProcessing && currentProcessingTask != null)
+                {
+                    return currentProcessingTask.Task;
+                }
+
+                // If we have a pending timer, stop it and create a new one
+                debounceTimer?.Dispose();
+
+                // Create a new task completion source if needed
+                if (currentProcessingTask == null)
+                {
+                    currentProcessingTask = new TaskCompletionSource<bool>();
+                }
+
+                // Start a new timer
+                debounceTimer = new Timer(
+                    ProcessQueueCallback,
+                    null,
+                    delayMilliseconds,
+                    Timeout.Infinite);
+
+                return currentProcessingTask.Task;
+            }
+        }
+
+        /// <summary>
+        /// Processes the queue immediately, bypassing any delay.
+        /// </summary>
+        /// <param name="cancellationToken">To cancel the operation.</param>
+        /// <returns>A task that completes when the queue has been processed.</returns>
+        public async Task ProcessQueueNow(CancellationToken cancellationToken = default)
+        {
+            lock (timerLock)
+            {
+                // Cancel any pending timer
+                debounceTimer?.Dispose();
+                debounceTimer = null;
+
+                // If we're already processing, return the current task
+                if (isProcessing && currentProcessingTask != null)
+                {
+                    return;
+                }
+
+                // Mark as processing
+                isProcessing = true;
+                
+                // Create a new task completion source if needed
+                if (currentProcessingTask == null)
+                {
+                    currentProcessingTask = new TaskCompletionSource<bool>();
+                }
+            }
+
+            try
+            {
+                await networkManager.Save(cancellationToken).ConfigureAwait(false);
+                
+                lock (timerLock)
+                {
+                    currentProcessingTask?.SetResult(true);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error processing queue");
+                
+                lock (timerLock)
+                {
+                    currentProcessingTask?.SetException(ex);
+                }
+                
+                throw;
+            }
+            finally
+            {
+                lock (timerLock)
+                {
+                    isProcessing = false;
+                    currentProcessingTask = null;
+                }
+            }
+        }
+
+        private Task ProcessQueueImmediately()
+        {
+            return ProcessQueueNow(CancellationToken.None);
+        }
+
+        private void ProcessQueueCallback(object? state)
+        {
+            // Start a new task to process the queue
+            _ = ProcessQueueNow();
+        }
+    }
+}

--- a/Jinaga/Patterns/PropertyPatterns.cs
+++ b/Jinaga/Patterns/PropertyPatterns.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;


### PR DESCRIPTION
Introduce a pause before processing the outgoing queue to improve fact collection. Add tests for queue processing using a counting fake network and a persistent memory store to handle quick succession scenarios. Clean up unnecessary using directives in test files.