### PR TITLE
Generate specifications with unique names

### DIFF
--- a/Jinaga.Test/Pipelines/InverseTest.cs
+++ b/Jinaga.Test/Pipelines/InverseTest.cs
@@ -151,8 +151,8 @@ namespace Jinaga.Test.Pipelines
                 """
                 (booking: Skylane.Booking [
                     !E {
-                        x: Skylane.Refund [
-                            x->booking: Skylane.Booking = booking
+                        x2: Skylane.Refund [
+                            x2->booking: Skylane.Booking = booking
                         ]
                     }
                 ]) {
@@ -181,8 +181,8 @@ namespace Jinaga.Test.Pipelines
                     booking: Skylane.Booking [
                         booking->flight: Skylane.Flight = flight
                         !E {
-                            x: Skylane.Refund [
-                                x->booking: Skylane.Booking = booking
+                            x2: Skylane.Refund [
+                                x2->booking: Skylane.Booking = booking
                             ]
                         }
                     ]
@@ -190,9 +190,9 @@ namespace Jinaga.Test.Pipelines
 
                 """,
                 """
-                (x: Skylane.Refund) {
+                (x2: Skylane.Refund) {
                     booking: Skylane.Booking [
-                        booking = x->booking: Skylane.Booking
+                        booking = x2->booking: Skylane.Booking
                     ]
                     flight: Skylane.Flight [
                         flight = booking->flight: Skylane.Flight

--- a/Jinaga.Test/Pipelines/InverseTest.cs
+++ b/Jinaga.Test/Pipelines/InverseTest.cs
@@ -1,3 +1,4 @@
+using Jinaga.Extensions;
 using Jinaga.Pipelines;
 using Jinaga.Test.Model;
 using System.Linq;
@@ -129,6 +130,88 @@ namespace Jinaga.Test.Pipelines
 
             inverses.Select(i => i.Operation).Should().BeEquivalentTo(new[] {
                 InverseOperation.Add,
+                InverseOperation.Remove
+            });
+        }
+
+        [Fact]
+        public void Inverse_TwoNegativeExistentialConditionsWithSameUnknownName()
+        {
+            var bookingsForAirlineDay = Given<AirlineDay>.Match(airlineDay =>
+                airlineDay.Successors().OfType<Flight>(flight => flight.airlineDay)
+                    .WhereNo((FlightCancellation x) => x.flight)
+                    .SelectMany(flight => flight.Successors().OfType<Booking>(booking => booking.flight))
+                    .WhereNo((Refund x) => x.booking)
+            );
+
+            var inverses = bookingsForAirlineDay.ComputeInverses();
+
+            inverses.Select(i => i.InverseSpecification.ToString().ReplaceLineEndings())
+                .Should().BeEquivalentTo([
+                """
+                (booking: Skylane.Booking [
+                    !E {
+                        x: Skylane.Refund [
+                            x->booking: Skylane.Booking = booking
+                        ]
+                    }
+                ]) {
+                    flight: Skylane.Flight [
+                        flight = booking->flight: Skylane.Flight
+                        !E {
+                            x: Skylane.Flight.Cancellation [
+                                x->flight: Skylane.Flight = flight
+                            ]
+                        }
+                    ]
+                    airlineDay: Skylane.Airline.Day [
+                        airlineDay = flight->airlineDay: Skylane.Airline.Day
+                    ]
+                } => booking
+
+                """,
+                """
+                (x: Skylane.Flight.Cancellation) {
+                    flight: Skylane.Flight [
+                        flight = x->flight: Skylane.Flight
+                    ]
+                    airlineDay: Skylane.Airline.Day [
+                        airlineDay = flight->airlineDay: Skylane.Airline.Day
+                    ]
+                    booking: Skylane.Booking [
+                        booking->flight: Skylane.Flight = flight
+                        !E {
+                            x: Skylane.Refund [
+                                x->booking: Skylane.Booking = booking
+                            ]
+                        }
+                    ]
+                } => booking
+
+                """,
+                """
+                (x: Skylane.Refund) {
+                    booking: Skylane.Booking [
+                        booking = x->booking: Skylane.Booking
+                    ]
+                    flight: Skylane.Flight [
+                        flight = booking->flight: Skylane.Flight
+                        !E {
+                            x: Skylane.Flight.Cancellation [
+                                x->flight: Skylane.Flight = flight
+                            ]
+                        }
+                    ]
+                    airlineDay: Skylane.Airline.Day [
+                        airlineDay = flight->airlineDay: Skylane.Airline.Day
+                    ]
+                } => booking
+
+                """
+                ]);
+            inverses.Select(i => i.Operation).Should().BeEquivalentTo(new[] {
+                InverseOperation.Add,
+                InverseOperation.Remove,
                 InverseOperation.Remove
             });
         }

--- a/Jinaga.Test/Specifications/SpecificationTest.cs
+++ b/Jinaga.Test/Specifications/SpecificationTest.cs
@@ -360,8 +360,8 @@ namespace Jinaga.Test.Specifications.Specifications
                     booking: Skylane.Booking [
                         booking->flight: Skylane.Flight = flight
                         !E {
-                            x: Skylane.Refund [
-                                x->booking: Skylane.Booking = booking
+                            x2: Skylane.Refund [
+                                x2->booking: Skylane.Booking = booking
                             ]
                         }
                     ]

--- a/Jinaga/Repository/SpecificationProcessor.cs
+++ b/Jinaga/Repository/SpecificationProcessor.cs
@@ -71,7 +71,7 @@ namespace Jinaga.Repository
                 lastLetterIndex--;
             }
             // The base name is every character up to and including the last letter.
-            string baseName = lastLetterIndex >= 0 ? recommendedName.Substring(0, lastLetterIndex + 1) : recommendedName;
+            string baseName = lastLetterIndex >= 0 ? recommendedName.Substring(0, lastLetterIndex + 1) : "unknown";
             int index = 2;
             string uniqueName = recommendedName;
             while (labelsUsed.Contains(uniqueName))

--- a/Jinaga/Repository/SpecificationProcessor.cs
+++ b/Jinaga/Repository/SpecificationProcessor.cs
@@ -64,14 +64,14 @@ namespace Jinaga.Repository
 
         private Label NewLabel(string recommendedName, string factType)
         {
-            // Find the last letter in the name.
-            int lastLetterIndex = recommendedName.Length - 1;
-            while (lastLetterIndex >= 0 && !char.IsLetter(recommendedName[lastLetterIndex]))
+            // Find the last non-digit in the name.
+            int lastNonDigitIndex = recommendedName.Length - 1;
+            while (lastNonDigitIndex >= 0 && char.IsDigit(recommendedName[lastNonDigitIndex]))
             {
-                lastLetterIndex--;
+                lastNonDigitIndex--;
             }
             // The base name is every character up to and including the last letter.
-            string baseName = lastLetterIndex >= 0 ? recommendedName.Substring(0, lastLetterIndex + 1) : "unknown";
+            string baseName = lastNonDigitIndex >= 0 ? recommendedName.Substring(0, lastNonDigitIndex + 1) : "unknown";
             int index = 2;
             string uniqueName = recommendedName;
             while (labelsUsed.Contains(uniqueName))

--- a/Jinaga/Repository/SpecificationProcessor.cs
+++ b/Jinaga/Repository/SpecificationProcessor.cs
@@ -24,8 +24,7 @@ namespace Jinaga.Repository
             var nonRepositoryParameters = specExpression.Parameters
                 .Where(parameter => parameter.Type != typeof(FactRepository));
             var symbolTable = processor.Given(nonRepositoryParameters);
-            var labelsUsed = processor.givenLabels.Select(g => g.Name).ToImmutableList();
-            var result = processor.ProcessSource(specExpression.Body, symbolTable, labelsUsed);
+            var result = processor.ProcessSource(specExpression.Body, symbolTable);
             processor.ValidateMatches(result.Matches);
             return (processor.givenLabels, result.Matches, result.Projection);
         }


### PR DESCRIPTION
Introduce tests to validate handling of multiple negative existential conditions using the same parameter name and ensure unique naming throughout the specification.

Fixes #160