### PR TITLE
Analyze and upgrade project dependencies

### DIFF
--- a/Jinaga.Notebooks/Jinaga.Notebooks.csproj
+++ b/Jinaga.Notebooks/Jinaga.Notebooks.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Html.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Data.Analysis" Version="0.22.0" />
+    <PackageReference Include="Microsoft.Data.Analysis" Version="0.22.2" />
   </ItemGroup>
 
   <ItemGroup>
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <PackageId>Jinaga.Notebooks</PackageId>
     <Authors>Michael L Perry</Authors>

--- a/Jinaga.Store.SQLite.Test/Jinaga.Store.SQLite.Test.csproj
+++ b/Jinaga.Store.SQLite.Test/Jinaga.Store.SQLite.Test.csproj
@@ -12,12 +12,12 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Jinaga.Store.SQLite/Jinaga.Store.SQLite.csproj
+++ b/Jinaga.Store.SQLite/Jinaga.Store.SQLite.csproj
@@ -31,7 +31,7 @@
 		<ProjectReference Include="..\Jinaga\Jinaga.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.8" />
+    <PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.11" />
   </ItemGroup>
 
 </Project>

--- a/Jinaga.Test/Jinaga.Test.csproj
+++ b/Jinaga.Test/Jinaga.Test.csproj
@@ -6,12 +6,12 @@
   <ItemGroup>
     <PackageReference Include="Fluentassertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Jinaga.Test/QueueProcessorTest.cs
+++ b/Jinaga.Test/QueueProcessorTest.cs
@@ -30,7 +30,7 @@ namespace Jinaga.Test
             await j.Fact(new TestFact("fact2"));
             await j.Fact(new TestFact("fact3"));
             
-            await Task.Delay(100); // Wait for debounce period
+            await Task.Delay(200); // Wait for debounce period
             
             // Assert
             network.SaveCallCount.Should().Be(1);

--- a/Jinaga.UnitTest/Jinaga.UnitTest.csproj
+++ b/Jinaga.UnitTest/Jinaga.UnitTest.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <PackageId>Jinaga.UnitTest</PackageId>
     <Authors>Michael L Perry</Authors>


### PR DESCRIPTION
Upgrade target frameworks to .NET 8 and update NuGet packages to their latest stable versions to improve support, security, and fix a test timing issue.

The `QueueProcessorTest.MultipleFacts_SavedInQuickSuccession_UsesSingleNetworkOperation` test was failing due to a timing issue after package updates, requiring an increased delay to ensure the network operation was correctly debounced.

---
<a href="https://cursor.com/background-agent?bcId=bc-c1847210-2c7f-4b18-9c28-02dbb219f74e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c1847210-2c7f-4b18-9c28-02dbb219f74e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

